### PR TITLE
Add memory access tracking and update recv_thread_fun

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -42,4 +42,18 @@ typedef struct {
   uint32_t ureg_vals[8];  // Unified registers shared by all threads in the same warp
 } reg_info_t;
 
+/* memory access information collected and passed
+ * on the channel from the GPU to the CPU */
+typedef struct {
+  message_header_t header;  // Common header with type=MSG_TYPE_MEM_ACCESS
+  uint64_t grid_launch_id;
+  int cta_id_x;
+  int cta_id_y;
+  int cta_id_z;
+  uint64_t pc;
+  int warp_id;
+  int opcode_id;
+  uint64_t addrs[32];
+} mem_access_t;
+
 #endif /* COMMON_H */

--- a/src/analysis.cu
+++ b/src/analysis.cu
@@ -39,27 +39,51 @@ void* recv_thread_fun(void*) {
     if (num_recv_bytes > 0) {
       uint32_t num_processed_bytes = 0;
       while (num_processed_bytes < num_recv_bytes) {
-        reg_info_t* ri = (reg_info_t*)&recv_buffer[num_processed_bytes];
+        // First read the message header to determine the message type
+        message_header_t* header = (message_header_t*)&recv_buffer[num_processed_bytes];
+        if (header->type == MSG_TYPE_REG_INFO) {
+          reg_info_t* ri = (reg_info_t*)&recv_buffer[num_processed_bytes];
 
-        /* when we get this cta_id_x it means the kernel has completed */
-        if (ri->cta_id_x == -1) {
-          break;
-        }
+          /* when we get this cta_id_x it means the kernel has completed */
+          if (ri->cta_id_x == -1) {
+            break;
+          }
 
-        // Simple instruction trace output
-        printf("CTA %d,%d,%d - warp %d - PC %ld - %s:\n", ri->cta_id_x, ri->cta_id_y, ri->cta_id_z, ri->warp_id, ri->pc,
-               (*g_id_to_sass_map)[ri->opcode_id].c_str());
+          // Simple instruction trace output
+          printf("CTA %d,%d,%d - warp %d - PC %ld - %s:\n", ri->cta_id_x, ri->cta_id_y, ri->cta_id_z, ri->warp_id,
+                 ri->pc, (*g_id_to_sass_map)[ri->opcode_id].c_str());
 
-        // Print register values
-        for (int reg_idx = 0; reg_idx < ri->num_regs; reg_idx++) {
-          printf("  * ");
-          for (int i = 0; i < 32; i++) {
-            printf("Reg%d_T%d: 0x%08x ", reg_idx, i, ri->reg_vals[i][reg_idx]);
+          // Print register values
+          for (int reg_idx = 0; reg_idx < ri->num_regs; reg_idx++) {
+            printf("  * ");
+            for (int i = 0; i < 32; i++) {
+              printf("Reg%d_T%d: 0x%08x ", reg_idx, i, ri->reg_vals[i][reg_idx]);
+            }
+            printf("\n");
           }
           printf("\n");
+          num_processed_bytes += sizeof(reg_info_t);
+        } else if (header->type == MSG_TYPE_MEM_ACCESS) {
+          // Process memory access message
+          mem_access_t* mem = (mem_access_t*)&recv_buffer[num_processed_bytes];
+
+          // Print memory access information
+          printf("CTA %d,%d,%d - warp %d - PC %ld - %s:\n", mem->cta_id_x, mem->cta_id_y, mem->cta_id_z, mem->warp_id,
+                 mem->pc, (*g_id_to_sass_map)[mem->opcode_id].c_str());
+          printf("  Memory Addresses:\n  * ");
+          int printed = 0;
+          for (int i = 0; i < 32; i++) {
+            if (mem->addrs[i] != 0) {  // Only print non-zero addresses
+              printf("T%d: 0x%016lx ", i, mem->addrs[i]);
+              printed++;
+              if (printed % 4 == 0 && i < 31) {
+                printf("\n    ");
+              }
+            }
+          }
+          printf("\n\n");
+          num_processed_bytes += sizeof(mem_access_t);
         }
-        printf("\n");
-        num_processed_bytes += sizeof(reg_info_t);
       }
     }
   }

--- a/src/cutracer.cu
+++ b/src/cutracer.cu
@@ -74,7 +74,9 @@ void instrument_function_if_needed(CUcontext ctx, CUfunction func) {
     uint32_t cnt = 0;
     /* iterate on all the static instructions in the function */
     for (auto instr : instrs) {
-      if (cnt < instr_begin_interval || cnt >= instr_end_interval) {
+      if (cnt < instr_begin_interval || cnt >= instr_end_interval ||
+          instr->getMemorySpace() == InstrType::MemorySpace::NONE ||
+          instr->getMemorySpace() == InstrType::MemorySpace::CONSTANT) {
         cnt++;
         continue;
       }
@@ -84,6 +86,7 @@ void instrument_function_if_needed(CUcontext ctx, CUfunction func) {
 
       std::vector<int> reg_num_list;
       std::vector<int> ureg_num_list;
+      int mref_idx = 0;
       int opcode_id = instr->getIdx();
       id_to_sass_map[opcode_id] = std::string(instr->getSass());
       /* iterate on the operands */
@@ -94,6 +97,30 @@ void instrument_function_if_needed(CUcontext ctx, CUfunction func) {
           for (int reg_idx = 0; reg_idx < instr->getSize() / 4; reg_idx++) {
             reg_num_list.push_back(op->u.reg.num + reg_idx);
           }
+        } else if (op->type == InstrType::OperandType::UREG) {
+          for (int reg_idx = 0; reg_idx < instr->getSize() / 4; reg_idx++) {
+            ureg_num_list.push_back(op->u.reg.num + reg_idx);
+          }
+        } else if (op->type == InstrType::OperandType::MREF) {
+          // TODO: double check this with NVIDIA people
+          if (op->u.mref.has_desc) {
+            ureg_num_list.push_back(op->u.mref.desc_ureg_num);
+            ureg_num_list.push_back(op->u.mref.desc_ureg_num + 1);
+          }
+          /* insert call to the instrumentation function with its
+           * arguments */
+          nvbit_insert_call(instr, "instrument_mem", IPOINT_BEFORE);
+          /* predicate value */
+          nvbit_add_call_arg_guard_pred_val(instr);
+          /* opcode id */
+          nvbit_add_call_arg_const_val32(instr, opcode_id);
+          /* memory reference 64 bit address */
+          nvbit_add_call_arg_mref_addr64(instr, mref_idx);
+          /* add instruction PC */
+          nvbit_add_call_arg_const_val64(instr, instr->getOffset());
+          /* add pointer to channel_dev*/
+          nvbit_add_call_arg_const_val64(instr, (uint64_t)&channel_dev);
+          mref_idx++;
         }
       }
 

--- a/src/inject_funcs.cu
+++ b/src/inject_funcs.cu
@@ -17,7 +17,7 @@
 /* for channel */
 #include "utils/channel.hpp"
 
-/* Based on NVIDIA code with Meta modifications for message type and unified register support */
+/* Based on NVIDIA NVBit reg_trace example with Meta modifications for message type and unified register support */
 #include "common.h"
 extern "C" __device__ __noinline__ void record_reg_val(int pred, int opcode_id, uint64_t pchannel_dev, uint64_t pc,
                                                        int32_t num_regs, int32_t num_uregs, ...) {
@@ -68,5 +68,41 @@ extern "C" __device__ __noinline__ void record_reg_val(int pred, int opcode_id, 
   if (first_laneid == laneid) {
     ChannelDev *channel_dev = (ChannelDev *)pchannel_dev;
     channel_dev->push(&ri, sizeof(reg_info_t));
+  }
+}
+
+/* Based on NVIDIA NVBit mem_trace example with Meta modifications for message type */
+extern "C" __device__ __noinline__ void instrument_mem(int pred, int opcode_id, uint64_t addr, uint64_t pc,
+                                                       uint64_t pchannel_dev) {
+  /* if thread is predicated off, return */
+  if (!pred) {
+    return;
+  }
+
+  int active_mask = __ballot_sync(__activemask(), 1);
+  const int laneid = get_laneid();
+  const int first_laneid = __ffs(active_mask) - 1;
+
+  mem_access_t ma;
+
+  ma.header.type = MSG_TYPE_MEM_ACCESS;
+
+  /* collect memory address information from other threads */
+  for (int i = 0; i < 32; i++) {
+    ma.addrs[i] = __shfl_sync(active_mask, addr, i);
+  }
+
+  int4 cta = get_ctaid();
+  ma.cta_id_x = cta.x;
+  ma.cta_id_y = cta.y;
+  ma.cta_id_z = cta.z;
+  ma.pc = pc;
+  ma.warp_id = get_global_warp_id();
+  ma.opcode_id = opcode_id;
+
+  /* first active lane pushes information on the channel */
+  if (first_laneid == laneid) {
+    ChannelDev *channel_dev = (ChannelDev *)pchannel_dev;
+    channel_dev->push(&ma, sizeof(mem_access_t));
   }
 }


### PR DESCRIPTION
Summary:
- Introduced a new `mem_access_t` structure in `common.h` to capture memory access information from the GPU.
- Enhanced `recv_thread_fun` in `analysis.cu` to process memory access messages, printing relevant details such as CTA IDs, program counter, and non-zero memory addresses.
- Updated `instrument_function_if_needed` in `cutracer.cu` to include instrumentation for memory references, allowing for detailed tracking of memory operations.
- Added a new device-side function `instrument_mem` in `inject_funcs.cu` to handle memory access instrumentation, pushing data to the channel for CPU-side processing.

These changes improve the tracing capabilities of the CUTracer tool, enabling better analysis of memory operations alongside register values.