### PR TITLE
[Feature] Improve Kernel Launch Tracking

### DIFF
--- a/include/analysis.h
+++ b/include/analysis.h
@@ -44,6 +44,9 @@ struct CTXstate {
   // recv thread sets it to FINISHED when it cleans up.
   // parent thread should wait until the state becomes FINISHED to clean up.
   volatile RecvThreadState recv_thread_done = RecvThreadState::STOP;
+
+  // map from function to map from offset to SASS string
+  std::map<CUfunction, std::map<int, std::string>> id_to_sass_map;
 };
 
 /* Receiver thread function */


### PR DESCRIPTION

This pull request implements the changes for "PR 2: Improve Kernel Launch Tracking" as outlined in the branch split analysis. The primary goal of this PR is to refactor the kernel launch tracking mechanism to support context-aware analysis, such as the upcoming instruction histogram feature.

## Key Changes

The core of this change is to move away from a global grid launch ID and a global SASS map. Instead, we now use a unique, global `kernel_launch_id` for each kernel launch and associate the SASS map (`id_to_sass_map`) directly with the `CUcontext` and `CUfunction`.

### Detailed Changes:

*   **`include/analysis.h`**:
    *   The `CTXstate` struct now contains a `std::map<CUfunction, std::map<int, std::string>> id_to_sass_map`. This links the SASS information directly to a function within a specific context, replacing the old global map.

*   **`src/cutracer.cu`**:
    *   Replaced `global_grid_launch_id` with `global_kernel_launch_id` to provide a unique identifier for each kernel launch.
    *   Introduced `kernel_launch_to_func_map` and `kernel_launch_to_iter_map` to allow for reverse lookup of the `CUfunction` and iteration count from a `kernel_launch_id`.
    *   Updated `enter_kernel_launch`, `leave_kernel_launch`, `nvbit_at_cuda_event`, and `nvbit_at_graph_node_launch` to use the new `global_kernel_launch_id`.
    *   `instrument_function_if_needed` now correctly uses the `id_to_sass_map` from the `CTXstate` struct.

*   **`src/analysis.cu`**:
    *   The `recv_thread_fun` has been updated to use the new tracking mechanism. It now uses the `kernel_launch_id` from the incoming messages to look up the corresponding `CUfunction` and retrieve the correct SASS data for analysis.
    *   Added error handling for unknown message types.

These changes provide a more robust and precise way to track kernel launches, which is a foundational requirement for more advanced, context-sensitive analysis features.

## Test Plan

```bash
% cd  ~/d/CUTracer/tests/py_add
% CUDA_INJECTION64_PATH=~/d/CUTracer/lib/cutracer.so KERNEL_FILTERS=vectorized_elementwise_kernel CUTRACER_INSTRUMENT=reg_trace python ./test_add.py
------------- NVBit (NVidia Binary Instrumentation Tool v1.7.5) Loaded --------------
NVBit core environment variables (mostly for nvbit-devs):
ACK_CTX_INIT_LIMITATION = 0 - if set, no warning will be printed for nvbit_at_ctx_init()
            NVDISASM = nvdisasm - override default nvdisasm found in PATH
            NOBANNER = 0 - if set, does not print this banner
       NO_EAGER_LOAD = 0 - eager module loading is turned on by NVBit to prevent potential NVBit tool deadlock, turn it off if you want to use the lazy module loading feature
---------------------------------------------------------------------------------
Log handle system initialized. Main log is cutracer_main_20250804_211226.log.
TOOL_VERBOSE = 0 (Enable verbosity inside the tool)
INSTR_BEGIN = 0 (Beginning of the instruction interval where to apply instrumentation)
INSTR_END = 4294967295 (End of the instruction interval where to apply instrumentation)
CUTRACER_INSTRUMENT = reg_trace (Instrumentation types to enable (reg_trace,mem_trace))
KERNEL_FILTERS = vectorized_elementwise_kernel (Kernel name filters)
Kernel name filters to instrument:
  - vectorized_elementwise_kernel
Using instrumentation types: reg_trace
  - Enabled: reg_trace (register value tracing)
----------------------------------------------------------------------------------------------------
WARNING: Do not call CUDA memory allocation in nvbit_at_ctx_init(). It will cause deadlocks. Do them in nvbit_tool_init(). If you encounter deadlocks, remove CUDA API calls to debug.
CUTracer: CTX 0x00005a59c2938ae0 - LAUNCH - Kernel pc 0x000075491d1feb00 - Kernel name void at::native::vectorized_elementwise_kernel<4, at::native::AbsFunctor<float>, std::array<char*, 2ul> >(int, at::native::AbsFunctor<float>, std::array<char*, 2ul>) - grid launch id 0 - grid size 1,1,1 - block size 128,1,1 - nregs 28 - shmem 0 - cuda stream id 0
Opened kernel trace log: kernel_83cecef946f0d4b5_iter0__ZN2at6native29vectorized_elementwise_kernelILi4ENS0_10AbsFunctorIfEESt5arrayIPcLm2EEEEviT0_T1_.log
CUTracer: CTX 0x00005a59c2938ae0 - LAUNCH - Kernel pc 0x000075491fa3be00 - Kernel name void at::native::vectorized_elementwise_kernel<4, at::native::AUnaryFunctor<float, float, bool, at::native::(anonymous namespace)::CompareEqFunctor<float> >, std::array<char*, 2ul> >(int, at::native::AUnaryFunctor<float, float, bool, at::native::(anonymous namespace)::CompareEqFunctor<float> >, std::array<char*, 2ul>) - grid launch id 1 - grid size 1,1,1 - block size 128,1,1 - nregs 28 - shmem 0 - cuda stream id 0
Opened kernel trace log: kernel_a09c2fc1961726e8_iter0__ZN2at6native29vectorized_elementwise_kernelILi4ENS0_13AUnaryFunctorIffbNS0_51_GLOBAL__N__28ce311f_18_CompareEQKernel_cu_d8008c9616CompareEqFunctorIfE.log
CUTracer: CTX 0x00005a59c2938ae0 - LAUNCH - Kernel pc 0x000075491fa5fa00 - Kernel name void at::native::vectorized_elementwise_kernel<4, at::native::BinaryFunctor<float, float, bool, at::native::(anonymous namespace)::CompareEqFunctor<float> >, std::array<char*, 3ul> >(int, at::native::BinaryFunctor<float, float, bool, at::native::(anonymous namespace)::CompareEqFunctor<float> >, std::array<char*, 3ul>) - grid launch id 2 - grid size 1,1,1 - block size 128,1,1 - nregs 38 - shmem 0 - cuda stream id 0
...
```