### PR TITLE
[Feature] Abstract Kernel Log Filename Generation

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -12,6 +12,10 @@
 #include <stdio.h>
 #include <time.h>
 
+#include <string>
+
+#include "cuda.h"
+
 // Forward declarations - use void* to avoid conflicts with CUDA types
 typedef void *CUcontext_ptr;
 typedef void *CUfunction_ptr;
@@ -64,5 +68,7 @@ void init_log_handle();
  * Cleans up the log handle system. Closes the main process log file.
  */
 void cleanup_log_handle();
+
+std::string generate_kernel_log_basename(CUcontext ctx, CUfunction func, uint32_t iteration);
 
 #endif /* LOG_HANDLE_H */


### PR DESCRIPTION

This pull request refactors the kernel log creation logic by abstracting the filename generation into a dedicated function. This change is a strategic improvement to our logging infrastructure, designed to support upcoming features like instruction histogram analysis, which will require more sophisticated and flexible log handling.

**Key Changes:**

1.  **Abstraction of Filename Generation:**
    *   A new function, `generate_kernel_log_basename`, has been introduced in `src/log.cu` and declared in `include/log.h`.
    *   This function generates a unique and descriptive base name for each kernel log file by combining a hash of the kernel's mangled name with a truncated version of the name itself (e.g., `kernel_<hash>_iter<iteration>_<truncated_kernel_name>`).


2.  **Simplified `log_open_kernel_file`:**
    *   The `log_open_kernel_file` function has been refactored to delegate filename creation to the new `generate_kernel_log_basename` function. This simplifies its responsibility to only managing the file handle.

**Benefits:**

*   **Improved Abstraction**: Centralizes the filename generation logic, making the code cleaner and easier to maintain.
*   **Foundation for Future Features**: Provides a robust and extensible logging infrastructure, which is a necessary prerequisite for the planned instruction histogram analysis feature.
*   **Enhanced Reusability**: The new function can be easily reused by other components that may need to generate kernel-specific identifiers or filenames in the future.
