### PR TITLE
Update TritonParse url

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -17,7 +17,7 @@ echo "CONDA_ENV: $CONDA_ENV"
 
 # Setup CUDA, conda, and pytorch
 echo "⬇️ Setting up dependencies using tritonparse setup script..."
-if curl -sL https://raw.githubusercontent.com/pytorch-labs/tritonparse/main/.ci/setup.sh | bash; then
+if curl -sL https://raw.githubusercontent.com/meta-pytorch/tritonparse/main/.ci/setup.sh | bash; then
     echo "✅ Dependencies setup complete."
 else
     echo "❌ Dependencies setup failed."


### PR DESCRIPTION
TrionParse has been moved to meta-pytorch. The url we used need to be updated. 
https://github.com/meta-pytorch/tritonparse/pull/52