### PR TITLE
[BE] Abstract kernel hash name computation; print it to log

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -69,6 +69,42 @@ void init_log_handle();
  */
 void cleanup_log_handle();
 
+/**
+ * Computes a per-kernel hash as a lowercase hexadecimal string (without the "0x" prefix).
+ *
+ * Implementation details:
+ * - Retrieves the mangled kernel name via nvbit_get_func_name(ctx, func, true).
+ * - Falls back to the literal string "unknown_kernel" when the name is not available.
+ * - Applies std::hash<std::string> to the full mangled name and formats the result in hex.
+ *
+ * Notes:
+ * - The exact numeric value of std::hash is implementation-dependent, but this function
+ *   is the single source of truth used by both cutracer.cu and log.cu, ensuring consistency
+ *   across modules in the same build.
+ * - When printing, prepend "0x" yourself if a prefixed form is desired (e.g., "0x%" + str).
+ */
+std::string compute_kernel_name_hash_hex(CUcontext ctx, CUfunction func);
+/**
+ * Builds a deterministic base filename for a kernel's trace log.
+ *
+ * Format:
+ *   "kernel_<hash_hex>_iter<iteration>_<truncated_mangled_name>"
+ *
+ * Details:
+ * - Uses the mangled kernel name and compute_kernel_name_hash_hex(ctx, func) to
+ *   derive a hex hash for uniqueness and name stability across modules.
+ * - Appends the kernel iteration number to distinguish repeated launches.
+ * - Includes a truncated (up to 150 chars) copy of the mangled name to aid
+ *   human readability while keeping the filename manageable.
+ *
+ * Args:
+ *   ctx: CUDA context associated with the kernel function.
+ *   func: The CUfunction handle of the kernel.
+ *   iteration: Per-kernel iteration counter maintained by the caller.
+ *
+ * Returns:
+ *   The base filename (without extension) for the kernel-specific log file.
+ */
 std::string generate_kernel_log_basename(CUcontext ctx, CUfunction func, uint32_t iteration);
 
 #endif /* LOG_HANDLE_H */

--- a/src/cutracer.cu
+++ b/src/cutracer.cu
@@ -276,6 +276,7 @@ static bool enter_kernel_launch(CUcontext ctx, CUfunction func, uint64_t &kernel
   /* get function name and pc */
   const char *func_name = nvbit_get_func_name(ctx, func);
   uint64_t pc = nvbit_get_func_addr(ctx, func);
+  std::string kernel_hash_hex = compute_kernel_name_hash_hex(ctx, func);
 
   // during stream capture or manual graph build, no kernel is launched, so
   // do not set launch argument, do not print kernel info, do not increase
@@ -288,21 +289,22 @@ static bool enter_kernel_launch(CUcontext ctx, CUfunction func, uint64_t &kernel
       cuLaunchKernelEx_params *p = (cuLaunchKernelEx_params *)params;
       loprintf(
           "CUTracer: CTX 0x%016lx - LAUNCH - Kernel pc 0x%016lx - "
-          "Kernel name %s - kernel launch id %ld - grid size %d,%d,%d "
+          "Kernel name %s - kernel hash 0x%s - kernel launch id %ld - grid size %d,%d,%d "
           "- block size %d,%d,%d - nregs %d - shmem %d - cuda stream "
           "id %ld\n",
-          (uint64_t)ctx, pc, func_name, kernel_launch_id, p->config->gridDimX, p->config->gridDimY, p->config->gridDimZ,
-          p->config->blockDimX, p->config->blockDimY, p->config->blockDimZ, nregs,
-          shmem_static_nbytes + p->config->sharedMemBytes, (uint64_t)p->config->hStream);
+          (uint64_t)ctx, pc, func_name, kernel_hash_hex.c_str(), kernel_launch_id, p->config->gridDimX,
+          p->config->gridDimY, p->config->gridDimZ, p->config->blockDimX, p->config->blockDimY, p->config->blockDimZ,
+          nregs, shmem_static_nbytes + p->config->sharedMemBytes, (uint64_t)p->config->hStream);
     } else {
       cuLaunchKernel_params *p = (cuLaunchKernel_params *)params;
       loprintf(
           "CUTracer: CTX 0x%016lx - LAUNCH - Kernel pc 0x%016lx - "
-          "Kernel name %s - kernel launch id %ld - grid size %d,%d,%d "
+          "Kernel name %s - kernel hash 0x%s - kernel launch id %ld - grid size %d,%d,%d "
           "- block size %d,%d,%d - nregs %d - shmem %d - cuda stream "
           "id %ld\n",
-          (uint64_t)ctx, pc, func_name, kernel_launch_id, p->gridDimX, p->gridDimY, p->gridDimZ, p->blockDimX,
-          p->blockDimY, p->blockDimZ, nregs, shmem_static_nbytes + p->sharedMemBytes, (uint64_t)p->hStream);
+          (uint64_t)ctx, pc, func_name, kernel_hash_hex.c_str(), kernel_launch_id, p->gridDimX, p->gridDimY,
+          p->gridDimZ, p->blockDimX, p->blockDimY, p->blockDimZ, nregs, shmem_static_nbytes + p->sharedMemBytes,
+          (uint64_t)p->hStream);
     }
 
     // For histogram analysis, we need to map the kernel launch ID back to its


### PR DESCRIPTION

### Summary
Introduce a stable per-kernel hash derived from the mangled kernel name, and surface it in logs and log file basenames.

### Changes
- Add `compute_kernel_name_hash_hex(CUcontext, CUfunction)` in `include/log.h`/`src/log.cu`
- Use the hex hash in `generate_kernel_log_basename(...)` for deterministic filenames
- Print kernel hash alongside kernel name in launch logs in `src/cutracer.cu`

### Behavior/Compatibility
- Log lines now include a kernel hash (lowercase hex) next to the kernel name
- Trace filenames now follow `kernel_<hash_hex>_iter<iteration>_<truncated_mangled_name>`
- No change to function signatures used externally; recompile required


### Files changed
- M	include/log.h
- M	src/cutracer.cu
- M	src/log.cu


### Testing
- Built locally; existing tests unaffected (no test changes in this branch)
