### PR TITLE
[Feature] Add deadlock_detection analysis switch

### DIFF
--- a/include/env_config.h
+++ b/include/env_config.h
@@ -31,6 +31,11 @@ enum class AnalysisType {
    * `OPCODE_ONLY` instrumentation.
    */
   PROTON_INSTR_HISTOGRAM = 1,
+
+  /**
+   * @brief Enables deadlock detection analysis.
+   */
+  DEADLOCK_DETECTION = 2,
 };
 
 // Configuration variables

--- a/src/env_config.cu
+++ b/src/env_config.cu
@@ -150,6 +150,16 @@ void init_analysis(const std::string &analysis_str) {
           "instrumentation.\n");
     }
   }
+
+  // deadlock_detection: enable analysis type and ensure REG_TRACE is on
+  if (analysis_str.find("deadlock_detection") != std::string::npos) {
+    enabled_analysis_types.insert(AnalysisType::DEADLOCK_DETECTION);
+    loprintf("  - Enabled: deadlock_detection\n");
+    if (!is_instrument_type_enabled(InstrumentType::REG_TRACE)) {
+      enabled_instrument_types.insert(InstrumentType::REG_TRACE);
+      loprintf("  - deadlock_detection: forcing reg_trace instrumentation\n");
+    }
+  }
 }
 
 /**
@@ -185,7 +195,8 @@ void init_config_from_env() {
   std::string kernel_filters_env;
   get_var_str(kernel_filters_env, "KERNEL_FILTERS", "", "Kernel name filters");
   std::string analysis_str;
-  get_var_str(analysis_str, "CUTRACER_ANALYSIS", "", "Analysis types to enable (proton_instr_histogram)");
+  get_var_str(analysis_str, "CUTRACER_ANALYSIS", "",
+              "Analysis types to enable (proton_instr_histogram, deadlock_detection)");
 
   //===== Initializations ==========
   // Get kernel name filters


### PR DESCRIPTION
**PR Summary:**

This pull request introduces a new analysis mode for deadlock detection, configurable via an environment variable. It expands the `CUTRACER_ANALYSIS` options to include `deadlock_detection` and ensures that the necessary instrumentation (`reg_trace`) is automatically enabled when this mode is active.

**Key Changes:**

*   **`AnalysisType` Enum Expansion:** Added `DEADLOCK_DETECTION` to the `AnalysisType` enum in `env_config.h`, formally defining the new analysis mode.
*   **Environment Variable Parsing:** The `init_analysis` function in `env_config.cu` now parses the `CUTRACER_ANALYSIS` string for `"deadlock_detection"`.
*   **Automatic Dependency Instrumentation:** When `deadlock_detection` is enabled, the system now automatically forces the `REG_TRACE` instrumentation type. This ensures that the required register tracing data is collected without needing separate user configuration, simplifying usability.
*   **Updated Documentation:** The help string for the `CUTRACER_ANALYSIS` environment variable has been updated to include `deadlock_detection` as an available option.

This change provides a simple and robust way to enable deadlock detection analysis and intelligently manages its instrumentation dependencies.
