### PR TITLE
[Feature] Statically detect EXIT opcodes in SASS

### DIFF
--- a/src/cutracer.cu
+++ b/src/cutracer.cu
@@ -201,14 +201,19 @@ bool instrument_function_if_needed(CUcontext ctx, CUfunction func) {
       }
     }
 
-    // Statically identify all "clock" instructions (CS2R SR_CLOCKLO) for this
-    // function. Their opcode IDs will be used at runtime to detect region
-    // boundaries.
+    // Statically identify special instructions for this function:
+    // - "clock" (CS2R SR_CLOCKLO) used for histogram region boundaries
+    // - "EXIT" used as a candidate signal for warp completion on host side
     if (should_instrument) {
       for (std::map<int, std::string>::const_iterator it_sass = ctx_state->id_to_sass_map[f].begin();
            it_sass != ctx_state->id_to_sass_map[f].end(); ++it_sass) {
-        if (strstr(it_sass->second.c_str(), "CS2R") && strstr(it_sass->second.c_str(), "SR_CLOCKLO")) {
+        const char *sass_cstr = it_sass->second.c_str();
+        if (strstr(sass_cstr, "CS2R") && strstr(sass_cstr, "SR_CLOCKLO")) {
           ctx_state->clock_opcode_ids[f].insert(it_sass->first);
+        }
+        // Simple substring detection for EXIT mnemonic (predication handled by extract on host side)
+        if (strstr(sass_cstr, "EXIT")) {
+          ctx_state->exit_opcode_ids[f].insert(it_sass->first);
         }
       }
     }


### PR DESCRIPTION
**PR Summary:**

This pull request enhances the static instrumentation analysis in `cutracer.cu` to identify special opcodes within a kernel's SASS. This lays the groundwork for more precise runtime tracing by pre-identifying instructions that signal critical events, such as region boundaries and warp completion.

**Key Changes:**

- **Expanded Opcode Identification:** The static analysis loop, which previously only searched for `CS2R SR_CLOCKLO` (clock) instructions, has been updated to also detect `EXIT` instructions.
- **`EXIT` Opcode Detection:** By identifying `EXIT` opcodes and storing their IDs, we can now use them at runtime as a primary signal for warp completion. This is a crucial step for accurately capturing full instruction histograms and analyzing warp lifetimes.
- **Code Refactoring:** The SASS string is now stored in a `const char*` variable (`sass_cstr`) for cleaner and more efficient repeated use within the loop.

This change improves the accuracy of our instruction tracing by enabling the host-side analysis to correctly interpret warp termination events based on the statically collected `EXIT` instruction IDs.
