### PR TITLE
Add End-to-End Test for Kernel Hang Detection

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -424,6 +424,7 @@ test_hang_test() {
 run_all_tests() {
   echo "🚀 Running all CUTracer tests..."
   # Test phase
+  build_vectoradd
   if ! test_vectoradd; then
     echo "❌ vectoradd test failed"
     return 1
@@ -443,15 +444,15 @@ run_all_tests() {
   return 0
 }
 
-# build_cutracer
+build_cutracer
 
 # Main execution
 case "$TEST_TYPE" in
 "build-only")
-  build_vectoradd
+  build_cutracer && build_vectoradd
   ;;
 "vectoradd")
-  test_vectoradd && test_py_add_with_kernel_filters
+  build_vectoradd && test_vectoradd && test_py_add_with_kernel_filters
   ;;
 "proton")
   test_proton

--- a/src/analysis.cu
+++ b/src/analysis.cu
@@ -285,6 +285,15 @@ static void update_loop_state(CTXstate *ctx_state, const WarpKey &key, const reg
       }
     }
   }
+
+  // Advance ring pointers
+  state.head = (uint8_t)((state.head + 1) % PC_HISTORY_LEN);
+  if (state.filled < PC_HISTORY_LEN) state.filled++;
+
+  // Only check for loops once the history buffer is full
+  if (state.filled < PC_HISTORY_LEN) {
+    return;
+  }
 }
 
 /**

--- a/src/analysis.cu
+++ b/src/analysis.cu
@@ -257,6 +257,31 @@ static uint64_t get_kernel_launch_id(const message_header_t *header) {
   }
 }
 
+/**
+ * @brief Updates the loop detection state for a given warp.
+ *
+ * This function is the core of the host-side loop detection logic. It maintains
+ * a history of instructions for each warp and uses it to detect when a warp
+ * enters a stable loop.
+ *
+ * The process for each new instruction is as follows:
+ * 1.  **History Update**: The new instruction record (`reg_info_t`) is added to
+ *     the warp's ring buffer. The function also tries to match it with any
+ *     pending memory access records for the same instruction.
+ * 2.  **Signature Calculation**: Once the history buffer is full, it calls
+ *     `compute_canonical_signature` to get a signature of the current PC sequence.
+ * 3.  **Loop State Tracking**:
+ *     - If the new signature and period match the previous one, a `repeat_cnt`
+ *       is incremented.
+ *     - If they don't match, the counter is reset.
+ *     - When `repeat_cnt` exceeds `LOOP_REPEAT_THRESH`, the warp is officially
+ *       considered to be in a loop (`loop_flag` is set to true), and the loop
+ *       body (one full period) is captured and stored.
+ *
+ * @param ctx_state Pointer to the state for the current CUDA context.
+ * @param key The `WarpKey` identifying the warp to be updated.
+ * @param ri Pointer to the `reg_info_t` packet for the current instruction.
+ */
 static void update_loop_state(CTXstate *ctx_state, const WarpKey &key, const reg_info_t *ri) {
   WarpLoopState &state = ctx_state->loop_states[key];
   // One-time buffer allocation per warp

--- a/src/analysis.cu
+++ b/src/analysis.cu
@@ -27,6 +27,7 @@
 #include "utils/channel.hpp"
 
 #define PC_HISTORY_LEN 32
+#define LOOP_REPEAT_THRESH 3
 
 extern pthread_mutex_t mutex;
 extern std::unordered_map<CUcontext, CTXstate *> ctx_state_map;
@@ -403,6 +404,31 @@ static void update_loop_state(CTXstate *ctx_state, const WarpKey &key, const reg
   // Compute canonical signature and period from the ring buffer
   uint8_t period = 0;
   uint64_t current_sig = compute_canonical_signature(state.history, PC_HISTORY_LEN, state.head, period);
+
+  if (current_sig != 0 && current_sig == state.last_sig && period == state.last_period) {
+    state.repeat_cnt++;
+  } else {
+    state.repeat_cnt = 1;  // current observed once
+    state.loop_flag = false;
+  }
+
+  if (state.repeat_cnt > LOOP_REPEAT_THRESH) {
+    if (!state.loop_flag) {
+      state.loop_flag = true;
+      state.first_loop_time = time(nullptr);
+      // Capture the loop body records (one period) from the ring buffer in chronological order
+      state.current_loop.period = period;
+      state.current_loop.instructions.clear();
+      state.current_loop.instructions.reserve(period);
+      // head points to oldest, so sequence starts from head index
+      for (uint8_t i = 0; i < period; ++i) {
+        int idx = (state.head + i) % PC_HISTORY_LEN;
+        state.current_loop.instructions.push_back(state.history[idx]);
+      }
+    }
+  }
+  state.last_sig = current_sig;
+  state.last_period = period;
 }
 
 /**

--- a/src/analysis.cu
+++ b/src/analysis.cu
@@ -504,7 +504,7 @@ static void check_kernel_hang(CTXstate *ctx_state, uint64_t current_kernel_launc
   if (all_warps_in_loop) {
     time_t hang_time = now - ctx_state->loop_states.begin()->second.first_loop_time;
     loprintf("Possible kernel hang: launch_id=%lu — all %zu active warps have been looping for %ld seconds.\n",
-            current_kernel_launch_id, ctx_state->active_warps.size(), hang_time);
+             current_kernel_launch_id, ctx_state->active_warps.size(), hang_time);
     // Deadlock sustained handling: count consecutive hits and terminate after threshold
     if (!ctx_state->deadlock_termination_initiated) {
       ctx_state->deadlock_consecutive_hits++;

--- a/src/analysis.cu
+++ b/src/analysis.cu
@@ -503,18 +503,20 @@ static void check_kernel_hang(CTXstate *ctx_state, uint64_t current_kernel_launc
 
   if (all_warps_in_loop) {
     time_t hang_time = now - ctx_state->loop_states.begin()->second.first_loop_time;
-    oprintf("Possible kernel hang: launch_id=%lu — all %zu active warps have been looping for %ld seconds.\n",
+    loprintf("Possible kernel hang: launch_id=%lu — all %zu active warps have been looping for %ld seconds.\n",
             current_kernel_launch_id, ctx_state->active_warps.size(), hang_time);
     // Deadlock sustained handling: count consecutive hits and terminate after threshold
     if (!ctx_state->deadlock_termination_initiated) {
       ctx_state->deadlock_consecutive_hits++;
       if (ctx_state->deadlock_consecutive_hits >= 3) {
         ctx_state->deadlock_termination_initiated = true;
-        oprintf("Deadlock sustained for %d checks; sending SIGTERM.\n", ctx_state->deadlock_consecutive_hits);
+        loprintf("Deadlock sustained for %d checks; sending SIGTERM.\n", ctx_state->deadlock_consecutive_hits);
+        fflush(stdout);
+        fflush(stderr);
         raise(SIGTERM);
         // Grace period; if not terminated externally, force kill
         sleep(2);
-        oprintf("Process still alive after SIGTERM; sending SIGKILL.\n");
+        loprintf("Process still alive after SIGTERM; sending SIGKILL.\n");
         raise(SIGKILL);
       }
     }

--- a/src/analysis.cu
+++ b/src/analysis.cu
@@ -258,6 +258,86 @@ static uint64_t get_kernel_launch_id(const message_header_t *header) {
 }
 
 /**
+ * @brief Computes a canonical signature for a sequence of PCs to detect loops.
+ *
+ * This function analyzes the recent history of Program Counters (PCs) for a warp
+ * to identify repeating patterns, which indicate a loop. The process involves:
+ * 1.  **Period Detection**: It finds the shortest repeating sequence of PCs in
+ *     the history buffer. If no repeating pattern is found, it returns 0.
+ * 2.  **Canonicalization**: To ensure that the same loop produces the same
+ *     signature regardless of the entry point, it finds the lexicographically
+ *     smallest rotation of the detected period. For example, `[3,1,2]` becomes
+ *     `[1,2,3]`.
+ * 3.  **Hashing**: It computes an FNV-1a hash of the canonical sequence, seeded
+ *     with the period length, to produce the final signature.
+ *
+ * @param history A constant reference to the ring buffer of merged trace records.
+ * @param ring_size The total size of the ring buffer (must be `PC_HISTORY_LEN`).
+ * @param head The index of the oldest element in the ring buffer.
+ * @param out_period A reference to a `uint8_t` that will be set to the detected
+ *                   period length. If no period is found, it's set to 0.
+ * @return A 64-bit canonical signature of the loop, or 0 if no loop is detected.
+ */
+static uint64_t compute_canonical_signature(const std::vector<TraceRecordMerged> &history, int ring_size, uint8_t head,
+                                            uint8_t &out_period) {
+  // Reconstruct linear PC sequence in chronological order (oldest -> newest).
+  uint64_t pcs[PC_HISTORY_LEN];
+  for (int i = 0; i < ring_size; ++i) {
+    int idx = (head + i) % ring_size;  // head points to oldest element position
+    pcs[i] = history[idx].reg.pc;
+  }
+
+  // Detect the shortest repeating period p (1..N-1) such that pcs[i] == pcs[i-p]
+  uint8_t period = 0;
+  for (uint8_t p = 1; p < ring_size; ++p) {
+    bool match = true;
+    for (uint8_t i = p; i < ring_size; ++i) {
+      if (pcs[i] != pcs[i - p]) {
+        match = false;
+        break;
+      }
+    }
+    if (match) {
+      period = p;
+      break;
+    }
+  }
+  if (period == 0) {
+    out_period = 0;
+    return 0;
+  }
+
+  // Find minimal rotation of the period segment to get canonical representation
+  // Build candidate of length period from the first period entries
+  uint64_t seg[PC_HISTORY_LEN];
+  for (uint8_t i = 0; i < period; ++i) seg[i] = pcs[i];
+  uint8_t min_rot = 0;
+  for (uint8_t r = 1; r < period; ++r) {
+    // Compare rotation r with current min_rot lexicographically
+    bool smaller = false;
+    for (uint8_t i = 0; i < period; ++i) {
+      uint64_t a = seg[(i + r) % period];
+      uint64_t b = seg[(i + min_rot) % period];
+      if (a == b) continue;
+      if (a < b) smaller = true;
+      break;
+    }
+    if (smaller) min_rot = r;
+  }
+
+  // FNV-1a style hash seeded by period for better distribution
+  const uint64_t FNV_OFFSET = 14695981039346656037ULL;
+  const uint64_t FNV_PRIME = 1099511628211ULL;
+  uint64_t h = FNV_OFFSET ^ period;
+  for (uint8_t i = 0; i < period; ++i) {
+    uint64_t pcv = seg[(i + min_rot) % period];
+    h = (h ^ pcv) * FNV_PRIME;
+  }
+  out_period = period;
+  return h;
+}
+
+/**
  * @brief Updates the loop detection state for a given warp.
  *
  * This function is the core of the host-side loop detection logic. It maintains
@@ -319,6 +399,10 @@ static void update_loop_state(CTXstate *ctx_state, const WarpKey &key, const reg
   if (state.filled < PC_HISTORY_LEN) {
     return;
   }
+
+  // Compute canonical signature and period from the ring buffer
+  uint8_t period = 0;
+  uint64_t current_sig = compute_canonical_signature(state.history, PC_HISTORY_LEN, state.head, period);
 }
 
 /**

--- a/src/analysis.cu
+++ b/src/analysis.cu
@@ -341,6 +341,31 @@ static uint64_t compute_canonical_signature(const std::vector<TraceRecordMerged>
   return h;
 }
 
+/**
+ * @brief Updates the loop detection state for a given warp.
+ *
+ * This function is the core of the host-side loop detection logic. It maintains
+ * a history of instructions for each warp and uses it to detect when a warp
+ * enters a stable loop.
+ *
+ * The process for each new instruction is as follows:
+ * 1.  **History Update**: The new instruction record (`reg_info_t`) is added to
+ *     the warp's ring buffer. The function also tries to match it with any
+ *     pending memory access records for the same instruction.
+ * 2.  **Signature Calculation**: Once the history buffer is full, it calls
+ *     `compute_canonical_signature` to get a signature of the current PC sequence.
+ * 3.  **Loop State Tracking**:
+ *     - If the new signature and period match the previous one, a `repeat_cnt`
+ *       is incremented.
+ *     - If they don't match, the counter is reset.
+ *     - When `repeat_cnt` exceeds `LOOP_REPEAT_THRESH`, the warp is officially
+ *       considered to be in a loop (`loop_flag` is set to true), and the loop
+ *       body (one full period) is captured and stored.
+ *
+ * @param ctx_state Pointer to the state for the current CUDA context.
+ * @param key The `WarpKey` identifying the warp to be updated.
+ * @param ri Pointer to the `reg_info_t` packet for the current instruction.
+ */
 static void update_loop_state(CTXstate *ctx_state, const WarpKey &key, const reg_info_t *ri) {
   WarpLoopState &state = ctx_state->loop_states[key];
   // One-time buffer allocation per warp

--- a/src/cutracer.cu
+++ b/src/cutracer.cu
@@ -201,14 +201,19 @@ bool instrument_function_if_needed(CUcontext ctx, CUfunction func) {
       }
     }
 
-    // Statically identify all "clock" instructions (CS2R SR_CLOCKLO) for this
-    // function. Their opcode IDs will be used at runtime to detect region
-    // boundaries.
+    // Statically identify special instructions for this function:
+    // - "clock" (CS2R SR_CLOCKLO) used for histogram region boundaries
+    // - "EXIT" used as a candidate signal for warp completion on host side
     if (should_instrument) {
       for (std::map<int, std::string>::const_iterator it_sass = ctx_state->id_to_sass_map[f].begin();
            it_sass != ctx_state->id_to_sass_map[f].end(); ++it_sass) {
-        if (strstr(it_sass->second.c_str(), "CS2R") && strstr(it_sass->second.c_str(), "SR_CLOCKLO")) {
+        const char *sass_cstr = it_sass->second.c_str();
+        if (strstr(sass_cstr, "CS2R") && strstr(sass_cstr, "SR_CLOCKLO")) {
           ctx_state->clock_opcode_ids[f].insert(it_sass->first);
+        }
+        // Simple substring detection for EXIT mnemonic (predication handled by extract on host side)
+        if (strstr(sass_cstr, "EXIT")) {
+          ctx_state->exit_opcode_ids[f].insert(it_sass->first);
         }
       }
     }

--- a/tests/hang_test/test_hang.py
+++ b/tests/hang_test/test_hang.py
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def add_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    if pid == 0:
+        while pid == pid:
+            tl.atomic_add(a_ptr, 1)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    a = tl.load(a_ptr + offsets, mask=mask)
+    b = tl.load(b_ptr + offsets, mask=mask)
+    c = a + b
+    tl.store(c_ptr + offsets, c, mask=mask)
+
+
+def tensor_add(a, b):
+    n_elements = a.numel()
+    c = torch.empty_like(a)
+    BLOCK_SIZE = 1024
+    grid = (triton.cdiv(n_elements, BLOCK_SIZE),)
+    add_kernel[grid](a, b, c, n_elements, BLOCK_SIZE)
+    return c
+
+
+def test_tensor_add():
+    torch.manual_seed(0)
+    size = (1024, 1024)
+    a = torch.randn(size, device="cuda", dtype=torch.float32)
+    b = torch.randn(size, device="cuda", dtype=torch.float32)
+
+    # Test Triton kernel
+    c_triton = tensor_add(a, b)
+    c_triton.sum()
+    tensor_add(a, b)
+    print("Triton kernel executed successfully")
+
+
+if __name__ == "__main__":
+    test_tensor_add()


### PR DESCRIPTION
## Summary

This pull request introduces a new end-to-end test to validate the correctness and reliability of the kernel hang detection feature. The test is designed to simulate a real-world kernel hang and verify that the tracer correctly identifies the condition and terminates the application.

## Key Components

- **New Triton-based Hang Test (`tests/hang_test/test_hang.py`):**
  - A new test case has been created using Triton.
  - It defines a custom CUDA kernel (`add_kernel`) that contains an **intentional infinite loop**. When launched, this kernel is guaranteed to hang, providing a perfect test scenario.

- **CI Test Function (`test_hang_test` in `.ci/run_tests.sh`):**
  - A new function has been added to the main CI script to execute the hang test.
  - The script runs the `test_hang.py` application with the `deadlock_detection` analysis enabled.
  - **Success Criteria:** The test is considered successful only if the tracer's log output contains the "Deadlock sustained" message, confirming that the hang was detected and the process was terminated by the tracer itself.
  - **Timeout Guard:** The test is wrapped in a `timeout` command to ensure that if the hang detector fails to fire, the CI job does not run indefinitely.

- **Reliability Improvements:**
  - The logging statements within the hang detection logic in `analysis.cu` have been updated to flush their buffers before process termination. This ensures that the log messages are reliably captured, which is critical for the test's validation step.

This test provides strong confidence that the hang detection mechanism is functioning correctly and can be relied upon to handle real kernel hangs.
