### PR TITLE
Add a new deadlock pattern detection

### DIFF
--- a/include/analysis.h
+++ b/include/analysis.h
@@ -180,6 +180,9 @@ struct CTXstate {
   std::unordered_map<WarpKey, time_t, WarpKey::Hash> last_seen_time_by_warp;
   std::unordered_map<WarpKey, time_t, WarpKey::Hash> exit_candidate_since_by_warp;
 
+  // Per-warp last observed state: whether last instruction was BAR.SYNC.DEFER_BLOCKING
+  std::unordered_map<WarpKey, bool, WarpKey::Hash> last_is_defer_blocking_by_warp;
+
   // Deadlock handling
   int deadlock_consecutive_hits = 0;
   bool deadlock_termination_initiated = false;

--- a/src/analysis.cu
+++ b/src/analysis.cu
@@ -37,6 +37,27 @@ extern std::unordered_map<CUcontext, CTXstate *> ctx_state_map;
 extern std::map<uint64_t, std::pair<CUcontext, CUfunction>> kernel_launch_to_func_map;
 extern std::map<uint64_t, uint32_t> kernel_launch_to_iter_map;
 
+// Forward declaration for helper defined below in this file
+std::string extract_instruction_name(const std::string &sass_line);
+
+static inline bool matches_barrier_defer_blocking(const std::string &mnemonic) {
+  if (mnemonic == "BAR.SYNC.DEFER_BLOCKING") return true;
+  // Conservative fallback: prefix BAR.SYNC and contains .DEFER_BLOCKING
+  if (mnemonic.rfind("BAR.SYNC", 0) == 0 && mnemonic.find(".DEFER_BLOCKING") != std::string::npos) return true;
+  return false;
+}
+
+static bool is_barrier_defer_blocking_for_opcode(CTXstate *ctx_state, CUfunction func, int opcode_id) {
+  if (!ctx_state) return false;
+  if (!ctx_state->id_to_sass_map.count(func)) return false;
+  const std::map<int, std::string> &sass_map = ctx_state->id_to_sass_map[func];
+  std::map<int, std::string>::const_iterator it = sass_map.find(opcode_id);
+  if (it == sass_map.end()) return false;
+  const std::string &sass_line = it->second;
+  std::string mnemonic = extract_instruction_name(sass_line);
+  return matches_barrier_defer_blocking(mnemonic);
+}
+
 /**
  * @brief Extracts the full instruction mnemonic from a SASS line.
  *
@@ -450,6 +471,7 @@ static void clear_deadlock_state(CTXstate *ctx_state) {
   ctx_state->pending_mem_by_warp.clear();
   ctx_state->last_seen_time_by_warp.clear();
   ctx_state->exit_candidate_since_by_warp.clear();
+  ctx_state->last_is_defer_blocking_by_warp.clear();
 }
 
 /**
@@ -639,21 +661,55 @@ static void check_kernel_hang(CTXstate *ctx_state, uint64_t current_kernel_launc
     }
   }
 
-  bool all_warps_in_loop = true;
-  for (const auto &warp_key : ctx_state->active_warps) {
-    if (ctx_state->loop_states.find(warp_key) == ctx_state->loop_states.end() ||
-        !ctx_state->loop_states.at(warp_key).loop_flag) {
-      all_warps_in_loop = false;
-      break;
+  size_t looping_cnt = 0;
+  size_t barrier_cnt = 0;
+  size_t progressing_cnt = 0;
+  bool candidate_hang = false;
+  for (const WarpKey &warp_key : ctx_state->active_warps) {
+    bool is_looping = false;
+    {
+      std::map<WarpKey, WarpLoopState>::const_iterator it = ctx_state->loop_states.find(warp_key);
+      if (it != ctx_state->loop_states.end() && it->second.loop_flag) is_looping = true;
     }
+
+    bool is_barrier = false;
+    {
+      std::unordered_map<WarpKey, bool, WarpKey::Hash>::const_iterator itBar =
+          ctx_state->last_is_defer_blocking_by_warp.find(warp_key);
+      if (itBar != ctx_state->last_is_defer_blocking_by_warp.end()) is_barrier = itBar->second;
+    }
+
+    if (is_barrier)
+      barrier_cnt++;
+    else if (is_looping)
+      looping_cnt++;
+    else
+      progressing_cnt++;
   }
 
-  if (all_warps_in_loop) {
-    time_t hang_time = now - ctx_state->loop_states.begin()->second.first_loop_time;
-    loprintf("Possible kernel hang: launch_id=%lu — all %zu active warps have been looping for %ld seconds.\n",
-             current_kernel_launch_id, ctx_state->active_warps.size(), hang_time);
+  // Hang trigger: no warp is progressing → kernel is effectively stalled.
+  // We partition active warps into three mutually exclusive categories:
+  //  - barrier: the last observed instruction is BAR.SYNC.DEFER_BLOCKING
+  //  - looping: not barrier and loop_flag == true (stable PC cycle detected)
+  //  - progressing: not barrier and loop_flag == false (still making forward progress)
+  // If progressing_cnt == 0 (and there are active warps), the system is stalled.
+  // This single condition covers the three intended hang scenarios:
+  //  (1) All barrier: barrier_cnt == active_warps.size(), looping_cnt == 0, progressing_cnt == 0
+  //  (2) Barrier + the rest looping: barrier_cnt > 0, looping_cnt > 0, progressing_cnt == 0
+  //  (3) All looping: looping_cnt == active_warps.size(), barrier_cnt == 0, progressing_cnt == 0
+  if (!ctx_state->active_warps.empty() && progressing_cnt == 0) {
+    candidate_hang = true;
+  }
+
+  if (candidate_hang) {
+    time_t hang_time = 0;
+    if (!ctx_state->loop_states.empty()) {
+      hang_time = now - ctx_state->loop_states.begin()->second.first_loop_time;
+    }
+    loprintf(
+        "Possible kernel hang: launch_id=%lu — state(looping=%zu, barrier=%zu, progressing=%zu) for %ld seconds.\n",
+        current_kernel_launch_id, looping_cnt, barrier_cnt, progressing_cnt, hang_time);
     print_warp_status_summary(ctx_state, current_kernel_launch_id);
-    // Deadlock sustained handling: count consecutive hits and terminate after threshold
     if (!ctx_state->deadlock_termination_initiated) {
       ctx_state->deadlock_consecutive_hits++;
       if (ctx_state->deadlock_consecutive_hits >= 3) {
@@ -662,15 +718,12 @@ static void check_kernel_hang(CTXstate *ctx_state, uint64_t current_kernel_launc
         fflush(stdout);
         fflush(stderr);
         raise(SIGTERM);
-        // Grace period; if not terminated externally, force kill
         sleep(2);
         loprintf("Process still alive after SIGTERM; sending SIGKILL.\n");
         raise(SIGKILL);
       }
     }
-    // Optional: Add detailed printout of loop info here
   } else {
-    // Reset hit counter if condition is not sustained
     ctx_state->deadlock_consecutive_hits = 0;
   }
 }
@@ -771,10 +824,18 @@ void *recv_thread_fun(void *args) {
             ctx_state->last_seen_time_by_warp[key] = time(nullptr);
             update_loop_state(ctx_state, key, ri);
 
-            // Mark EXIT candidate if this opcode_id is an EXIT for the current function
+            // Determine if current instruction is BAR.SYNC.DEFER_BLOCKING
+            bool is_barrier_defer = false;
+            CUfunction f_func2 = nullptr;
             auto func_iter2 = kernel_launch_to_func_map.find(ri->kernel_launch_id);
             if (func_iter2 != kernel_launch_to_func_map.end()) {
-              CUfunction f_func2 = func_iter2->second.second;
+              f_func2 = func_iter2->second.second;
+              is_barrier_defer = is_barrier_defer_blocking_for_opcode(ctx_state, f_func2, ri->opcode_id);
+            }
+            ctx_state->last_is_defer_blocking_by_warp[key] = is_barrier_defer;
+
+            // Mark EXIT candidate if this opcode_id is an EXIT for the current function
+            if (func_iter2 != kernel_launch_to_func_map.end()) {
               if (ctx_state->exit_opcode_ids.count(f_func2) &&
                   ctx_state->exit_opcode_ids[f_func2].count(ri->opcode_id)) {
                 if (!ctx_state->exit_candidate_since_by_warp.count(key)) {


### PR DESCRIPTION
- **What**
  - Introduce a simplified hang detection rule: if there are active warps and no warp is progressing, treat as hang.
  - Classify each warp into one of three states:
    - barrier: last instruction is `BAR.SYNC.DEFER_BLOCKING`
    - looping: not barrier and `loop_flag == true`
    - progressing: not barrier and `loop_flag == false`
  - Trigger when `progressing_cnt == 0`. This covers: all barrier; barrier + the rest looping; all looping.

- **Why**
  - Remove reliance on time/count heuristics for barrier waiting in the hang decision.
  - Make the criterion explicit and robust: “no forward progress” means hang.

- **Key Changes**
  - `include/analysis.h`
    - Add `last_is_defer_blocking_by_warp` map to store last-instruction barrier status per warp.
  - `src/analysis.cu`
    - Add helpers to identify `BAR.SYNC.DEFER_BLOCKING` from SASS:
      - `extract_instruction_name(...)`
      - `matches_barrier_defer_blocking(...)`
      - `is_barrier_defer_blocking_for_opcode(...)`
    - Update `recv_thread_fun` to set `last_is_defer_blocking_by_warp` on each `REG_INFO`.
    - Clear `last_is_defer_blocking_by_warp` in `clear_deadlock_state`.
    - Rework `check_kernel_hang` to compute `(looping_cnt, barrier_cnt, progressing_cnt)` and trigger on `progressing_cnt == 0`.
    - Improve logs to print: `state(looping=..., barrier=..., progressing=...)`.

- **Behavior**
  - Hang is detected when no warp is progressing; logging shows the breakdown for diagnosis.
  - Existing throttling and consecutive-hit termination flow remain.

## Test Plan

```bash
CUDA_INJECTION64_PATH=/home/yhao/CUTracer/lib/cutracer.so CUTRACER_ANALYSIS=deadlock_detection KERNEL_FILTERS=gdpa_kernel_tma_ws_blackwell python run.py --op gdpa --only tlx_gdpa_fwd --sparsity 1.0 --head 4 --dim 512 --max_seq_len 1000 --batch 1152
```
The warp status printing in the log file is like the below:
```log
    Warp1747[145,0,0]: LOOPING(period=2, repeat=564, 5s) 
      Loop Body (2 instructions):
        [0] PC 76848; Offset 76848 /*0x00012c30*/;  @!P0 BRA 0x12e20 ;
        [1] PC 76832; Offset 76832 /*0x00012c20*/;  SYNCS.PHASECHK.TRANS64.TRYWAIT P0, [R0+URZ+0x38130], R3 ;
    Warp1748[145,0,0]: BARRIER(inactive=8s) no_loop(period=0, repeat=0) 
    Warp1749[145,0,0]: BARRIER(inactive=8s) no_loop(period=0, repeat=0) 
    Warp1750[145,0,0]: LOOPING(period=2, repeat=529, 4s) 
      Loop Body (2 instructions):
        [0] PC 76992; Offset 76992 /*0x00012cc0*/;  @!P1 BRA 0x12eb0 ;
        [1] PC 76976; Offset 76976 /*0x00012cb0*/;  SYNCS.PHASECHK.TRANS64.TRYWAIT P1, [UR5], R6 ;
    Warp1751[145,0,0]: LOOPING(period=2, repeat=503, 4s) 
      Loop Body (2 instructions):
        [0] PC 77664; Offset 77664 /*0x00012f60*/;  @!P0 BRA 0x13150 ;
        [1] PC 77648; Offset 77648 /*0x00012f50*/;  SYNCS.PHASECHK.TRANS64.TRYWAIT P0, [UR9+0x20], R2 ;
    Warp1752[146,0,0]: LOOPING(period=2, repeat=748, 5s) 
      Loop Body (2 instructions):
        [0] PC 77760; Offset 77760 /*0x00012fc0*/;  @!P0 BRA 0x131b0 ;
        [1] PC 77744; Offset 77744 /*0x00012fb0*/;  SYNCS.PHASECHK.TRANS64.TRYWAIT P0, [UR7+0x38110], R3 ;
```
