### PR TITLE
[Feature] Add CUBIN Dump Feature

### DIFF
--- a/include/env_config.h
+++ b/include/env_config.h
@@ -42,6 +42,7 @@ enum class AnalysisType {
 extern uint32_t instr_begin_interval;
 extern uint32_t instr_end_interval;
 extern int verbose;
+extern bool dump_cubin;
 
 // Kernel name filters
 extern std::vector<std::string> kernel_filters;

--- a/src/cutracer.cu
+++ b/src/cutracer.cu
@@ -145,7 +145,11 @@ bool instrument_function_if_needed(CUcontext ctx, CUfunction func) {
     if (!should_instrument) {
       continue;
     }
-
+    if (dump_cubin) {
+      std::string kernel_hash_hex = compute_kernel_name_hash_hex(ctx, f);
+      std::string cubin_filename = std::string(nvbit_get_func_name(ctx, f)) + "_0x" + kernel_hash_hex + ".cubin";
+      nvbit_dump_cubin(ctx, f, cubin_filename.c_str());
+    }
     uint32_t cnt = 0;
     /* iterate on all the static instructions in the function */
     for (auto instr : instrs) {

--- a/src/env_config.cu
+++ b/src/env_config.cu
@@ -17,6 +17,7 @@
 uint32_t instr_begin_interval;
 uint32_t instr_end_interval;
 int verbose;
+bool dump_cubin;
 // kernel name filters
 std::vector<std::string> kernel_filters;
 // enabled instrumentation types
@@ -184,6 +185,9 @@ void init_config_from_env() {
   init_log_handle();
   // Get other configuration variables
   get_var_int(verbose, "TOOL_VERBOSE", 0, "Enable verbosity inside the tool");
+  int dump_cubin_int = 0;
+  get_var_int(dump_cubin_int, "CUTRACER_DUMP_CUBIN", 0, "Dump cubin files for instrumented kernels");
+  dump_cubin = (dump_cubin_int != 0);
   // If INSTRS is not set, fall back to the old INSTR_BEGIN/INSTR_END behavior
   get_var_uint32(instr_begin_interval, "INSTR_BEGIN", 0,
                  "Beginning of the instruction interval where to apply instrumentation");


### PR DESCRIPTION

## Overview
fix https://github.com/facebookresearch/CUTracer/issues/46

This PR adds a new feature to dump CUBIN (CUDA Binary) files for instrumented kernels, controlled by an environment variable. This allows users to inspect the actual binary code that gets executed on the GPU.

## Motivation

- **Binary Inspection**: Enables developers to examine the compiled CUBIN files to understand the actual GPU assembly code
- **Debugging**: Helps with debugging and performance analysis by providing access to the low-level binary representation
- **Optional Feature**: Implemented as an opt-in feature via environment variable to avoid overhead when not needed

## Changes

### 1. Environment Configuration (`include/env_config.h`, `src/env_config.cu`)

- Added new boolean configuration variable `dump_cubin`
- Reads from `CUTRACER_DUMP_CUBIN` environment variable (default: 0/disabled)
- Integrated into existing configuration initialization system

### 2. Core Instrumentation Logic (`src/cutracer.cu`)

- Added conditional CUBIN dump in `instrument_function_if_needed()` function
- Only dumps CUBIN files when:
  - `CUTRACER_DUMP_CUBIN=1` is set
  - Kernel matches the instrumentation filters (respects `KERNEL_FILTERS`)
- CUBIN filename format: `{kernel_name}_0x{kernel_hash}.cubin`
  - Uses kernel hash to ensure uniqueness
  - Includes full kernel name (mangled) for easy identification

### 3. Implementation Details

- Uses existing `nvbit_dump_cubin()` API from NVBit
- File naming uses `compute_kernel_name_hash_hex()` for consistent hash generation
- Output location: current working directory
- Only dumps for kernels that pass the instrumentation filter

## Usage

```bash
CUDA_INJECTION64_PATH=~/d/CUTracer/lib/cutracer.so CUTRACER_DUMP_CUBIN=1  python your_script
```

### Example Output

When enabled, CUBIN files will be created in the current directory:

```
_Z6vecAddPdS_S_i_0xa1b2c3d4.cubin
_Z10matmulImplIfEEvPT_PKS0_S3_ii_0xabcdef12.cubin
```

These files can be inspected using tools like `cuobjdump` or `nvdisasm`:

```bash
# Disassemble CUBIN file
nvdisasm -gp -gi -g -c _Z6vecAddPdS_S_i_0xa1b2c3d4.cubin

# Extract information
cuobjdump -sass _Z6vecAddPdS_S_i_0xa1b2c3d4.cubin
```

## Configuration Output

When the tool starts, you'll see the configuration in the log:

```
CUTRACER_DUMP_CUBIN = 1 (Dump cubin files for instrumented kernels)
```

## Testing

Tested with:
- Simple vector addition kernels
- Successfully generates CUBIN files with correct naming
- Verified files can be disassembled with `nvdisasm`
- No performance impact when feature is disabled (default)

## Backward Compatibility

- ✅ Fully backward compatible
- ✅ Feature is opt-in (disabled by default)
- ✅ No changes to existing behavior when `CUTRACER_DUMP_CUBIN` is not set
- ✅ Works with existing `KERNEL_FILTERS` configuration

## Future Enhancements

Potential improvements for future PRs:
- Add `CUTRACER_DUMP_CUBIN_DIR` to specify output directory
- Support for dumping all kernels vs. only filtered ones
- Automatic subdirectory organization by kernel hash or name
- Integration with existing log file output directory system

## Files Changed

- `include/env_config.h` - Added `dump_cubin` extern declaration
- `src/env_config.cu` - Added configuration variable and initialization
- `src/cutracer.cu` - Added conditional CUBIN dump logic

## Related NVBit API

Uses `nvbit_dump_cubin(CUcontext cuctx, CUfunction cufunc, const char *filename)` from NVBit core API.
