### PR TITLE
Warp Statistics Feature Implementation

### DIFF
--- a/src/analysis.cu
+++ b/src/analysis.cu
@@ -585,7 +585,7 @@ static void update_loop_state(CTXstate* ctx_state, const WarpKey& key, const reg
  * @param ctx_state Pointer to the state for the current CUDA context.
  * @param kernel_launch_id The kernel launch ID to clear tracking data for (0 to skip).
  */
-static void clear_deadlock_state(CTXstate *ctx_state, uint64_t kernel_launch_id = 0) {
+static void clear_deadlock_state(CTXstate* ctx_state, uint64_t kernel_launch_id = 0) {
   ctx_state->loop_states.clear();
   ctx_state->active_warps.clear();
   ctx_state->pending_mem_by_warp.clear();
@@ -611,12 +611,12 @@ static void clear_deadlock_state(CTXstate *ctx_state, uint64_t kernel_launch_id 
  * @param ctx_state Pointer to the state for the current CUDA context
  * @param current_kernel_launch_id The current kernel launch ID for context
  */
-static void print_warp_status_summary(CTXstate *ctx_state, uint64_t current_kernel_launch_id) {
+static void print_warp_status_summary(CTXstate* ctx_state, uint64_t current_kernel_launch_id) {
   time_t now = time(nullptr);
 
   // Print warp statistics if available
   if (ctx_state->kernel_warp_tracking.count(current_kernel_launch_id)) {
-    const KernelWarpStats &stats = ctx_state->kernel_warp_tracking[current_kernel_launch_id];
+    const KernelWarpStats& stats = ctx_state->kernel_warp_tracking[current_kernel_launch_id];
     size_t total_warps = stats.total_warps;
     size_t seen_warps = stats.all_seen_warps.size();
     size_t finished_warps = stats.finished_warps.size();
@@ -627,16 +627,16 @@ static void print_warp_status_summary(CTXstate *ctx_state, uint64_t current_kern
     std::set<int> active_warp_ids;
     std::set<int> never_executed_warp_ids;
 
-    for (const WarpKey &key : stats.finished_warps) {
+    for (const WarpKey& key : stats.finished_warps) {
       finished_warp_ids.insert(key.warp_id);
     }
-    for (const WarpKey &key : ctx_state->active_warps) {
+    for (const WarpKey& key : ctx_state->active_warps) {
       active_warp_ids.insert(key.warp_id);
     }
 
     // Calculate never executed warps (all possible warp IDs minus those we've seen)
     std::set<int> all_seen_warp_ids;
-    for (const WarpKey &key : stats.all_seen_warps) {
+    for (const WarpKey& key : stats.all_seen_warps) {
       all_seen_warp_ids.insert(key.warp_id);
     }
 
@@ -664,7 +664,7 @@ static void print_warp_status_summary(CTXstate *ctx_state, uint64_t current_kern
              total_warps > 0 ? 100.0 * never_executed / total_warps : 0.0);
 
     // Helper lambda to format ranges from a set of IDs
-    auto format_ranges = [](const std::set<int> &ids) -> std::string {
+    auto format_ranges = [](const std::set<int>& ids) -> std::string {
       if (ids.empty()) return "none";
 
       std::string result;
@@ -882,7 +882,7 @@ static void check_kernel_hang(CTXstate* ctx_state, uint64_t current_kernel_launc
     }
   }
   if (!to_remove.empty()) {
-    for (const WarpKey &key : to_remove) {
+    for (const WarpKey& key : to_remove) {
       // Track this warp as finished before removing it from active_warps
       if (ctx_state->kernel_warp_tracking.count(current_kernel_launch_id)) {
         ctx_state->kernel_warp_tracking[current_kernel_launch_id].finished_warps.insert(key);
@@ -1048,8 +1048,8 @@ void* recv_thread_fun(void* args) {
           // Initialize kernel warp tracking for the new kernel
           if (is_analysis_type_enabled(AnalysisType::DEADLOCK_DETECTION)) {
             if (kernel_launch_to_dimensions_map.count(current_launch_id)) {
-              KernelDimensions &dims = kernel_launch_to_dimensions_map[current_launch_id];
-              KernelWarpStats &stats = ctx_state->kernel_warp_tracking[current_launch_id];
+              KernelDimensions& dims = kernel_launch_to_dimensions_map[current_launch_id];
+              KernelWarpStats& stats = ctx_state->kernel_warp_tracking[current_launch_id];
               stats.dimensions = dims;
 
               // Calculate total warps: grid_size * warps_per_block

--- a/src/analysis.cu
+++ b/src/analysis.cu
@@ -36,6 +36,7 @@ extern pthread_mutex_t mutex;
 extern std::unordered_map<CUcontext, CTXstate*> ctx_state_map;
 extern std::map<uint64_t, std::pair<CUcontext, CUfunction>> kernel_launch_to_func_map;
 extern std::map<uint64_t, uint32_t> kernel_launch_to_iter_map;
+extern std::map<uint64_t, KernelDimensions> kernel_launch_to_dimensions_map;
 
 // Forward declaration for helper defined below in this file
 std::string extract_instruction_name(const std::string& sass_line);
@@ -332,6 +333,7 @@ void dump_previous_kernel_data(uint64_t kernel_launch_id, const std::vector<Regi
     // Clean up mapping tables to free memory for subsequent kernels.
     kernel_launch_to_func_map.erase(kernel_launch_id);
     kernel_launch_to_iter_map.erase(kernel_launch_id);
+    kernel_launch_to_dimensions_map.erase(kernel_launch_id);
   }
 }
 
@@ -581,14 +583,20 @@ static void update_loop_state(CTXstate* ctx_state, const WarpKey& key, const reg
  * and pending memory operations.
  *
  * @param ctx_state Pointer to the state for the current CUDA context.
+ * @param kernel_launch_id The kernel launch ID to clear tracking data for (0 to skip).
  */
-static void clear_deadlock_state(CTXstate* ctx_state) {
+static void clear_deadlock_state(CTXstate *ctx_state, uint64_t kernel_launch_id = 0) {
   ctx_state->loop_states.clear();
   ctx_state->active_warps.clear();
   ctx_state->pending_mem_by_warp.clear();
   ctx_state->last_seen_time_by_warp.clear();
   ctx_state->exit_candidate_since_by_warp.clear();
   ctx_state->last_is_defer_blocking_by_warp.clear();
+
+  // Clear kernel warp tracking for the specified kernel
+  if (kernel_launch_id != 0) {
+    ctx_state->kernel_warp_tracking.erase(kernel_launch_id);
+  }
 }
 
 /**
@@ -603,13 +611,108 @@ static void clear_deadlock_state(CTXstate* ctx_state) {
  * @param ctx_state Pointer to the state for the current CUDA context
  * @param current_kernel_launch_id The current kernel launch ID for context
  */
-static void print_warp_status_summary(CTXstate* ctx_state, uint64_t current_kernel_launch_id) {
+static void print_warp_status_summary(CTXstate *ctx_state, uint64_t current_kernel_launch_id) {
+  time_t now = time(nullptr);
+
+  // Print warp statistics if available
+  if (ctx_state->kernel_warp_tracking.count(current_kernel_launch_id)) {
+    const KernelWarpStats &stats = ctx_state->kernel_warp_tracking[current_kernel_launch_id];
+    size_t total_warps = stats.total_warps;
+    size_t seen_warps = stats.all_seen_warps.size();
+    size_t finished_warps = stats.finished_warps.size();
+    size_t active_warps = ctx_state->active_warps.size();
+
+    // Collect warp IDs in different categories
+    std::set<int> finished_warp_ids;
+    std::set<int> active_warp_ids;
+    std::set<int> never_executed_warp_ids;
+
+    for (const WarpKey &key : stats.finished_warps) {
+      finished_warp_ids.insert(key.warp_id);
+    }
+    for (const WarpKey &key : ctx_state->active_warps) {
+      active_warp_ids.insert(key.warp_id);
+    }
+
+    // Calculate never executed warps (all possible warp IDs minus those we've seen)
+    std::set<int> all_seen_warp_ids;
+    for (const WarpKey &key : stats.all_seen_warps) {
+      all_seen_warp_ids.insert(key.warp_id);
+    }
+
+    // Determine max warp ID based on total warps
+    for (uint32_t wid = 0; wid < total_warps; wid++) {
+      if (all_seen_warp_ids.count(wid) == 0) {
+        never_executed_warp_ids.insert(wid);
+      }
+    }
+
+    size_t never_executed = never_executed_warp_ids.size();
+
+    loprintf("==> WARP STATISTICS for kernel_launch_id=%lu:\n", current_kernel_launch_id);
+    loprintf("    Grid: <%u,%u,%u>, Block: <%u,%u,%u>\n", stats.dimensions.gridDimX, stats.dimensions.gridDimY,
+             stats.dimensions.gridDimZ, stats.dimensions.blockDimX, stats.dimensions.blockDimY,
+             stats.dimensions.blockDimZ);
+    loprintf("\n");
+    loprintf("    Summary:\n");
+    loprintf("      Total warps:           %5zu (100.0%%)\n", total_warps);
+    loprintf("      Finished warps:        %5zu (%5.1f%%)\n", finished_warps,
+             total_warps > 0 ? 100.0 * finished_warps / total_warps : 0.0);
+    loprintf("      Active warps:          %5zu (%5.1f%%)\n", active_warps,
+             total_warps > 0 ? 100.0 * active_warps / total_warps : 0.0);
+    loprintf("      Never executed warps:  %5zu (%5.1f%%)\n", never_executed,
+             total_warps > 0 ? 100.0 * never_executed / total_warps : 0.0);
+
+    // Helper lambda to format ranges from a set of IDs
+    auto format_ranges = [](const std::set<int> &ids) -> std::string {
+      if (ids.empty()) return "none";
+
+      std::string result;
+      auto it = ids.begin();
+      int range_start = *it;
+      int range_end = *it;
+
+      for (++it; it != ids.end(); ++it) {
+        if (*it == range_end + 1) {
+          // Continue current range
+          range_end = *it;
+        } else {
+          // End current range and start new one
+          if (!result.empty()) result += ", ";
+          if (range_start == range_end) {
+            result += std::to_string(range_start);
+          } else {
+            result += std::to_string(range_start) + "-" + std::to_string(range_end);
+          }
+          range_start = range_end = *it;
+        }
+      }
+
+      // Add final range
+      if (!result.empty()) result += ", ";
+      if (range_start == range_end) {
+        result += std::to_string(range_start);
+      } else {
+        result += std::to_string(range_start) + "-" + std::to_string(range_end);
+      }
+
+      return result;
+    };
+
+    loprintf("\n");
+    loprintf("    Warp ID Ranges:\n");
+    loprintf("      Finished:       %s\n", format_ranges(finished_warp_ids).c_str());
+    loprintf("      Active:         %s\n", format_ranges(active_warp_ids).c_str());
+    loprintf("      Never executed: %s\n", format_ranges(never_executed_warp_ids).c_str());
+
+    loprintf("    -----------------------------------------------------------------------\n");
+  }
+
   if (ctx_state->active_warps.empty()) {
     loprintf("==> WARP STATUS: No active warps for kernel_launch_id=%lu\n", current_kernel_launch_id);
     return;
   }
 
-  time_t now = time(nullptr);
   loprintf("==> WARP STATUS SUMMARY for kernel_launch_id=%lu (%zu active warps):\n", current_kernel_launch_id,
            ctx_state->active_warps.size());
   loprintf("    Format: WarpID[CTA_x,y,z] - LoopStatus - Activity\n");
@@ -779,7 +882,12 @@ static void check_kernel_hang(CTXstate* ctx_state, uint64_t current_kernel_launc
     }
   }
   if (!to_remove.empty()) {
-    for (const WarpKey& key : to_remove) {
+    for (const WarpKey &key : to_remove) {
+      // Track this warp as finished before removing it from active_warps
+      if (ctx_state->kernel_warp_tracking.count(current_kernel_launch_id)) {
+        ctx_state->kernel_warp_tracking[current_kernel_launch_id].finished_warps.insert(key);
+      }
+
       ctx_state->active_warps.erase(key);
       ctx_state->loop_states.erase(key);
       ctx_state->pending_mem_by_warp.erase(key);
@@ -932,10 +1040,26 @@ void* recv_thread_fun(void* args) {
               warp_states.clear();
             }
             if (is_analysis_type_enabled(AnalysisType::DEADLOCK_DETECTION)) {
-              clear_deadlock_state(ctx_state);
+              clear_deadlock_state(ctx_state, last_seen_kernel_launch_id);
             }
           }
           last_seen_kernel_launch_id = current_launch_id;
+
+          // Initialize kernel warp tracking for the new kernel
+          if (is_analysis_type_enabled(AnalysisType::DEADLOCK_DETECTION)) {
+            if (kernel_launch_to_dimensions_map.count(current_launch_id)) {
+              KernelDimensions &dims = kernel_launch_to_dimensions_map[current_launch_id];
+              KernelWarpStats &stats = ctx_state->kernel_warp_tracking[current_launch_id];
+              stats.dimensions = dims;
+
+              // Calculate total warps: grid_size * warps_per_block
+              // Each block has (blockDim.x * blockDim.y * blockDim.z + 31) / 32 warps
+              uint32_t threads_per_block = dims.blockDimX * dims.blockDimY * dims.blockDimZ;
+              uint32_t warps_per_block = (threads_per_block + 31) / 32;
+              uint32_t total_blocks = dims.gridDimX * dims.gridDimY * dims.gridDimZ;
+              stats.total_warps = total_blocks * warps_per_block;
+            }
+          }
         }
 
         if (header->type == MSG_TYPE_REG_INFO) {
@@ -949,6 +1073,12 @@ void* recv_thread_fun(void* args) {
             ctx_state->active_warps.insert(key);
             // Update last seen time for this warp
             ctx_state->last_seen_time_by_warp[key] = time(nullptr);
+
+            // Track this warp in the kernel's all_seen_warps set
+            if (ctx_state->kernel_warp_tracking.count(ri->kernel_launch_id)) {
+              ctx_state->kernel_warp_tracking[ri->kernel_launch_id].all_seen_warps.insert(key);
+            }
+
             update_loop_state(ctx_state, key, ri);
 
             // Determine if current instruction is BAR.SYNC.DEFER_BLOCKING

--- a/src/cutracer.cu
+++ b/src/cutracer.cu
@@ -328,7 +328,7 @@ static bool enter_kernel_launch(CUcontext ctx, CUfunction func, uint64_t& kernel
     // Store kernel dimensions for warp statistics tracking
     KernelDimensions dims;
     if (cbid == API_CUDA_cuLaunchKernelEx_ptsz || cbid == API_CUDA_cuLaunchKernelEx) {
-      cuLaunchKernelEx_params *p = (cuLaunchKernelEx_params *)params;
+      cuLaunchKernelEx_params* p = (cuLaunchKernelEx_params*)params;
       dims.gridDimX = p->config->gridDimX;
       dims.gridDimY = p->config->gridDimY;
       dims.gridDimZ = p->config->gridDimZ;
@@ -336,7 +336,7 @@ static bool enter_kernel_launch(CUcontext ctx, CUfunction func, uint64_t& kernel
       dims.blockDimY = p->config->blockDimY;
       dims.blockDimZ = p->config->blockDimZ;
     } else {
-      cuLaunchKernel_params *p = (cuLaunchKernel_params *)params;
+      cuLaunchKernel_params* p = (cuLaunchKernel_params*)params;
       dims.gridDimX = p->gridDimX;
       dims.gridDimY = p->gridDimY;
       dims.gridDimZ = p->gridDimZ;

--- a/src/cutracer.cu
+++ b/src/cutracer.cu
@@ -70,6 +70,7 @@ uint64_t global_kernel_launch_id = 0;
 // Global mapping tables for kernel launch tracking
 std::map<uint64_t, std::pair<CUcontext, CUfunction>> kernel_launch_to_func_map;
 std::map<uint64_t, uint32_t> kernel_launch_to_iter_map;
+std::map<uint64_t, KernelDimensions> kernel_launch_to_dimensions_map;
 
 // map to store the iteration count for each kernel
 static std::map<CUfunction, uint32_t> kernel_iter_map;
@@ -323,6 +324,27 @@ static bool enter_kernel_launch(CUcontext ctx, CUfunction func, uint64_t& kernel
     uint32_t current_iter = kernel_iter_map[func];
     kernel_launch_to_func_map[kernel_launch_id] = {ctx, func};
     kernel_launch_to_iter_map[kernel_launch_id] = current_iter;
+
+    // Store kernel dimensions for warp statistics tracking
+    KernelDimensions dims;
+    if (cbid == API_CUDA_cuLaunchKernelEx_ptsz || cbid == API_CUDA_cuLaunchKernelEx) {
+      cuLaunchKernelEx_params *p = (cuLaunchKernelEx_params *)params;
+      dims.gridDimX = p->config->gridDimX;
+      dims.gridDimY = p->config->gridDimY;
+      dims.gridDimZ = p->config->gridDimZ;
+      dims.blockDimX = p->config->blockDimX;
+      dims.blockDimY = p->config->blockDimY;
+      dims.blockDimZ = p->config->blockDimZ;
+    } else {
+      cuLaunchKernel_params *p = (cuLaunchKernel_params *)params;
+      dims.gridDimX = p->gridDimX;
+      dims.gridDimY = p->gridDimY;
+      dims.gridDimZ = p->gridDimZ;
+      dims.blockDimX = p->blockDimX;
+      dims.blockDimY = p->blockDimY;
+      dims.blockDimZ = p->blockDimZ;
+    }
+    kernel_launch_to_dimensions_map[kernel_launch_id] = dims;
 
     // increment kernel launch id for next launch
     // kernel id can be changed here, since nvbit_set_at_launch() has copied


### PR DESCRIPTION

## PR Summary

This PR adds comprehensive warp tracking and statistics to CUTracer's deadlock detection system, providing complete visibility into kernel execution progress and warp status.

**Key Improvements:**
- ✅ Tracks total warps based on grid/block dimensions (automatically calculated)
- ✅ Monitors all warps throughout kernel execution (seen/active/finished/never-executed)
- ✅ Displays clear statistics with both aggregate counts and precise warp ID ranges
- ✅ Automatically merges consecutive warp IDs into ranges for compact display
- ✅ Helps identify deadlock patterns, scheduling issues, and execution bottlenecks

**Output Format:**
```
Summary:                    ← High-level statistics (counts & percentages)
  Total/Finished/Active/Never executed

Warp ID Ranges:            ← Detailed breakdown (which specific warps)
  Finished:       0-31, 128-200
  Active:         32-127
  Never executed: 256-1023
```

## Overview
This feature adds comprehensive warp tracking statistics to CUTracer's deadlock detection system. It tracks and reports the status of all warps in a kernel launch.

## What Was Added

### 1. New Data Structures (analysis.h)
- `KernelDimensions`: Stores grid and block dimensions for a kernel launch
- `KernelWarpStats`: Tracks complete warp statistics per kernel:
  - Total warps (calculated from grid/block dimensions)
  - All warps ever seen executing
  - Finished warps (completed execution)
  - Active warps (currently executing)

### 2. Tracking Implementation

#### In cutracer.cu:
- Added `kernel_launch_to_dimensions_map` to store kernel dimensions
- Modified `enter_kernel_launch()` to capture and store grid/block dimensions

#### In analysis.cu:
- Added extern declaration for dimensions map
- Modified `recv_thread_fun()` to:
  - Initialize warp tracking when a new kernel starts
  - Calculate total warps: `(gridDim * warps_per_block)`
  - Track all warps seen during execution
- Modified `check_kernel_hang()` to mark warps as finished when removed from active set
- Modified `clear_deadlock_state()` to clean up per-kernel tracking data
- Modified `dump_previous_kernel_data()` to clean up dimensions map

### 3. Statistics Display

Modified `print_warp_status_summary()` to display warp statistics in two clear sections:

#### Section 1: Summary (Statistics)
Shows aggregate counts and percentages:
```
    Summary:
      Total warps:           N (100.0%)
      Finished warps:        F ( X.X%)
      Active warps:          A ( X.X%)
      Never executed warps:  N ( X.X%)
```

#### Section 2: Warp ID Ranges (Detailed Breakdown)
Shows which specific warp IDs are in each state, with consecutive IDs merged into ranges:
```
    Warp ID Ranges:
      Finished:       0-31, 128-200
      Active:         32-127
      Never executed: 256-1023
```

**Features:**
- Consecutive warp IDs are automatically merged (e.g., `0-31`)
- Non-consecutive ranges are comma-separated (e.g., `0-31, 128-200`)
- Single warps shown individually (e.g., `42`)
- Empty categories shown as `none`

## How It Works

1. **Kernel Launch**: When a kernel launches, dimensions are captured
2. **First Message**: When first trace arrives for new kernel:
   - Total warps calculated
   - Tracking structures initialized
3. **During Execution**: Each warp trace updates `all_seen_warps`
4. **Warp Completion**: When warp becomes inactive, moved to `finished_warps`
5. **Hang Detection**: Statistics displayed when potential hang detected
6. **Cleanup**: All tracking data cleaned when kernel completes

## Benefits

1. **Complete Visibility**: Know exactly how many warps exist vs executing
2. **Never-Executed Detection**: Identify warps that never started (potential scheduling issues)
3. **Progress Tracking**: See what percentage of warps completed at a glance
4. **Precise ID Tracking**: Know exactly which warp IDs are in each state (finished/active/never)
5. **Pattern Recognition**: Easily spot patterns like "first N warps stuck" or "specific range never executed"
6. **Clear Presentation**: Two-section format separates statistics from details
7. **Compact Display**: Consecutive IDs merged into ranges for readability (e.g., `0-1023` instead of listing 1024 IDs)
8. **Debugging Aid**: Helps identify if deadlock affects specific warp ranges or scattered warps

## Example Output

### Example 1: Small Kernel with Partial Completion
```
==> WARP STATISTICS for kernel_launch_id=42:
    Grid: <8,1,1>, Block: <256,1,1>

    Summary:
      Total warps:            64 (100.0%)
      Finished warps:         32 ( 50.0%)
      Active warps:           20 ( 31.3%)
      Never executed warps:   12 ( 18.8%)

    Warp ID Ranges:
      Finished:       0-19, 50-61
      Active:         20-39
      Never executed: 40-49, 62-63
    -----------------------------------------------------------------------
```

**Analysis:**
- 50% of warps completed successfully
- 31% are still running (potential hang)
- 19% never executed (potential scheduling issue)
- The pattern shows warps 40-49 were never scheduled

### Example 2: Large Kernel with Near Completion
```
==> WARP STATISTICS for kernel_launch_id=2:
    Grid: <1024,1,1>, Block: <128,1,1>

    Summary:
      Total warps:           4096 (100.0%)
      Finished warps:        4092 ( 99.9%)
      Active warps:             4 (  0.1%)
      Never executed warps:     0 (  0.0%)

    Warp ID Ranges:
      Finished:       4-4095
      Active:         0-3
      Never executed: none
    -----------------------------------------------------------------------
```

**Analysis:**
- Nearly complete execution with only 4 warps still active
- The first 4 warps (0-3) are the ones still running
- All warps were scheduled and executed
