### PR TITLE
[NDJSON Trace] Add NDJSON trace format infrastructure PR2a

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,37 @@
 # Prerequisites
 *.d
 
+
+# Python specific
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.pdb
+*.egg
+*.egg-info/
+dist/
+build/
+pip-wheel-metadata/
+*.manifest
+*.spec
+*.coverage
+.coverage.*
+.cache
+.pytest_cache/
+.tox/
+.mypy_cache/
+.dmypy.json
+.pyre/
+.pytype/
+*.ipynb_checkpoints
+*.ipynb
+.env/
+.venv/
+env/
+venv/
+# End of Python specific
+
 # Compiled Object files
 *.slo
 *.lo
@@ -77,3 +108,4 @@ compile_commands.json
 *.ttgir
 *.ptx
 *.sass
+*.ndjson

--- a/include/analysis.h
+++ b/include/analysis.h
@@ -21,6 +21,9 @@
 /* for channel */
 #include "utils/channel.hpp"
 
+// Forward declaration for TraceWriter (defined in trace_writer.h)
+class TraceWriter;
+
 /* Channel buffer size */
 #define CHANNEL_SIZE (1l << 20)
 
@@ -227,6 +230,13 @@ struct CTXstate {
 
   // Warp statistics tracking per kernel launch
   std::unordered_map<uint64_t, KernelWarpStats> kernel_warp_tracking;
+
+  // TraceWriter for JSON output (mode 1/2), nullptr if mode 0 (text)
+  TraceWriter* trace_writer = nullptr;
+
+  // Per-kernel trace index counter (monotonically increasing)
+  // Maps kernel_launch_id -> current trace_index
+  std::unordered_map<uint64_t, uint64_t> trace_index_by_kernel;
 };
 
 // =================================================================================

--- a/include/trace_writer.h
+++ b/include/trace_writer.h
@@ -1,0 +1,231 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/*
+ * SPDX-FileCopyrightText: Copyright (c) Meta Platforms, Inc. and affiliates.
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <nlohmann/json.hpp>
+#include <string>
+
+#include "common.h"
+#include "nvbit.h"
+
+/**
+ * @brief Rich trace record combining GPU trace data with metadata.
+ *
+ * This structure acts as an intermediate layer between raw GPU communication
+ * structs (reg_info_t, mem_access_t, opcode_only_t) and the JSON output format.
+ *
+ * Benefits:
+ * - GPU communication protocol remains unchanged
+ * - Easy to add metadata fields without modifying GPU structs
+ * - One record = one JSON line (atomic write operation)
+ */
+struct TraceRecord {
+  // ========== Metadata (not in original GPU structs) ==========
+
+  /**
+   * @brief CUDA context pointer (for debugging/correlation).
+   *
+   * Source: recv_thread_fun() args
+   * JSON field: "ctx" (hex string)
+   */
+  CUcontext context;
+
+  /**
+   * @brief SASS instruction string for human readability.
+   *
+   * Source: ctx_state->id_to_sass_map[func][opcode_id]
+   * JSON field: "sass"
+   */
+  std::string sass_instruction;
+
+  /**
+   * @brief Per-kernel trace sequence number (monotonically increasing).
+   *
+   * Used to track trace ordering within a kernel for analysis.
+   * Source: Maintained by analysis.cu per kernel_launch_id
+   * JSON field: "trace_index"
+   */
+  uint64_t trace_index;
+
+  /**
+   * @brief Host-side timestamp when trace was received (nanoseconds).
+   *
+   * Source: Current time when trace is processed
+   * JSON field: "timestamp"
+   */
+  uint64_t timestamp;
+
+  // ========== Original trace data ==========
+
+  /**
+   * @brief Type of the trace record.
+   */
+  message_type_t type;
+
+  /**
+   * @brief Union containing pointer to original GPU data.
+   *
+   * Lifetime: Caller ensures the pointed-to struct remains valid
+   * until write_trace() completes (typically local variable in analysis.cu).
+   */
+  union {
+    const reg_info_t* reg_info;
+    const mem_access_t* mem_access;
+    const opcode_only_t* opcode_only;
+  } data;
+
+  // ========== Constructors for convenience ==========
+
+  /**
+   * @brief Create a TraceRecord for reg_info_t.
+   */
+  static TraceRecord create_reg_trace(CUcontext ctx, const std::string& sass, uint64_t trace_idx, uint64_t ts,
+                                      const reg_info_t* reg) {
+    TraceRecord record;
+    record.context = ctx;
+    record.sass_instruction = sass;
+    record.trace_index = trace_idx;
+    record.timestamp = ts;
+    record.type = MSG_TYPE_REG_INFO;
+    record.data.reg_info = reg;
+    return record;
+  }
+
+  /**
+   * @brief Create a TraceRecord for mem_access_t.
+   */
+  static TraceRecord create_mem_trace(CUcontext ctx, const std::string& sass, uint64_t trace_idx, uint64_t ts,
+                                      const mem_access_t* mem) {
+    TraceRecord record;
+    record.context = ctx;
+    record.sass_instruction = sass;
+    record.trace_index = trace_idx;
+    record.timestamp = ts;
+    record.type = MSG_TYPE_MEM_ACCESS;
+    record.data.mem_access = mem;
+    return record;
+  }
+
+  /**
+   * @brief Create a TraceRecord for opcode_only_t.
+   */
+  static TraceRecord create_opcode_trace(CUcontext ctx, const std::string& sass, uint64_t trace_idx, uint64_t ts,
+                                         const opcode_only_t* opcode) {
+    TraceRecord record;
+    record.context = ctx;
+    record.sass_instruction = sass;
+    record.trace_index = trace_idx;
+    record.timestamp = ts;
+    record.type = MSG_TYPE_OPCODE_ONLY;
+    record.data.opcode_only = opcode;
+    return record;
+  }
+};
+
+/**
+ * @brief TraceWriter for trace output in multiple formats.
+ *
+ * Unified writer supporting three output modes:
+ * - Mode 0: Text format (legacy .log files)
+ * - Mode 1: NDJSON + Zstd compression (.ndjson.zstd)
+ * - Mode 2: NDJSON uncompressed (.ndjson)
+ *
+ * Key features:
+ * - Single unified API: write_trace(TraceRecord)
+ * - Automatic format dispatch based on trace_mode
+ * - Buffering for I/O efficiency
+ * - Metadata (ctx, sass, trace_index, timestamp) automatically included
+ */
+class TraceWriter {
+ private:
+  std::string filename_;
+  FILE* file_handle_;
+  std::string json_buffer_;
+  size_t buffer_threshold_;
+  int trace_mode_;  // 0, 1, or 2
+  bool enabled_;
+
+ public:
+  /**
+   * @brief Construct TraceWriter.
+   *
+   * @param filename Base filename (extension added automatically based on mode)
+   * @param trace_mode 0 for text, 1 for compressed JSON, 2 for uncompressed JSON
+   * @param buffer_threshold Buffer flush threshold (default 1MB)
+   */
+  TraceWriter(const std::string& filename, int trace_mode, size_t buffer_threshold = 1024 * 1024);
+
+  /**
+   * @brief Destructor - flushes remaining data and closes file.
+   */
+  ~TraceWriter();
+
+  // Disable copy
+  TraceWriter(const TraceWriter&) = delete;
+  TraceWriter& operator=(const TraceWriter&) = delete;
+
+  /**
+   * @brief Write a trace record to output.
+   *
+   * Mode 0: Formats as text and writes to .log file
+   * Mode 1/2: Serializes to JSON and writes to .ndjson[.zstd] file
+   *
+   * @param record Complete trace record with all information
+   * @return true if successful, false on error
+   */
+  bool write_trace(const TraceRecord& record);
+
+  /**
+   * @brief Flush buffered data to disk.
+   */
+  void flush();
+
+  /**
+   * @brief Check if writer is functional.
+   */
+  bool is_enabled() const {
+    return enabled_;
+  }
+
+ private:
+  // ========== Output methods ==========
+
+  /**
+   * @brief Write record in text format (mode 0).
+   */
+  void write_text_format(const TraceRecord& record);
+
+  /**
+   * @brief Write record in JSON format (mode 1/2).
+   */
+  void write_json_format(const TraceRecord& record);
+
+  /**
+   * @brief Write uncompressed buffer to file (mode 2).
+   */
+  void write_uncompressed();
+
+  // ========== JSON serialization ==========
+
+  /**
+   * @brief Serialize reg_info_t fields to JSON object.
+   */
+  void serialize_reg_info(nlohmann::json& j, const reg_info_t* reg);
+
+  /**
+   * @brief Serialize mem_access_t fields to JSON object.
+   */
+  void serialize_mem_access(nlohmann::json& j, const mem_access_t* mem);
+
+  /**
+   * @brief Serialize opcode_only_t fields to JSON object.
+   */
+  void serialize_opcode_only(nlohmann::json& j, const opcode_only_t* opcode);
+};

--- a/src/trace_writer.cpp
+++ b/src/trace_writer.cpp
@@ -1,0 +1,322 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/*
+ * SPDX-FileCopyrightText: Copyright (c) Meta Platforms, Inc. and affiliates.
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "trace_writer.h"
+
+#include <iomanip>
+#include <nlohmann/json.hpp>
+#include <sstream>
+#include <stdexcept>
+
+// ============================================================================
+// Constructor & Destructor
+// ============================================================================
+
+TraceWriter::TraceWriter(const std::string& filename, int trace_mode, size_t buffer_threshold)
+    : filename_(filename),
+      file_handle_(nullptr),
+      buffer_threshold_(buffer_threshold),
+      trace_mode_(trace_mode),
+      enabled_(true) {
+  // Validate trace mode
+  if (trace_mode < 0 || trace_mode > 2) {
+    fprintf(stderr, "TraceWriter: Invalid trace_mode %d (must be 0, 1, or 2)\\n", trace_mode);
+    enabled_ = false;
+    return;
+  }
+
+  // Note: Mode 1 (compression) will be implemented in a future PR
+  if (trace_mode == 1) {
+    fprintf(stderr, "TraceWriter: Mode 1 (compression) is not yet implemented\\n");
+    fprintf(stderr, "TraceWriter: Please use mode 0 (text) or mode 2 (NDJSON)\\n");
+    enabled_ = false;
+    return;
+  }
+
+  // Determine filename and open mode based on trace mode
+  std::string actual_filename;
+  const char* open_mode;
+
+  if (trace_mode == 0) {
+    // Mode 0: Text format
+    actual_filename = filename + ".log";
+    open_mode = "a";  // Append text mode
+  } else {            // trace_mode == 2
+    // Mode 2: NDJSON uncompressed
+    actual_filename = filename + ".ndjson";
+    open_mode = "a";  // Append text mode
+  }
+
+  file_handle_ = fopen(actual_filename.c_str(), open_mode);
+
+  if (!file_handle_) {
+    fprintf(stderr, "TraceWriter: Failed to open %s\\n", actual_filename.c_str());
+    enabled_ = false;
+    return;
+  }
+}
+
+TraceWriter::~TraceWriter() {
+  // Flush any remaining data
+  flush();
+
+  // Close file
+  if (file_handle_) {
+    fclose(file_handle_);
+  }
+
+  // Zstd context cleanup will be added when mode 1 is implemented
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+bool TraceWriter::write_trace(const TraceRecord& record) {
+  if (!enabled_) return false;
+
+  // Dispatch based on trace mode
+  if (trace_mode_ == 0) {
+    write_text_format(record);
+  } else {
+    write_json_format(record);
+  }
+
+  return true;
+}
+
+void TraceWriter::flush() {
+  // Currently only mode 2 is implemented
+  write_uncompressed();
+}
+
+// ============================================================================
+// Private Helpers
+// ============================================================================
+
+void TraceWriter::write_uncompressed() {
+  if (json_buffer_.empty() || !enabled_) return;
+
+  // Write JSON buffer directly to file
+  if (file_handle_) {
+    size_t written = fwrite(json_buffer_.data(), 1, json_buffer_.size(), file_handle_);
+    if (written != json_buffer_.size()) {
+      fprintf(stderr, "TraceWriter: Write error (wrote %zu of %zu bytes)\n", written, json_buffer_.size());
+    }
+
+    fflush(file_handle_);
+  }
+
+  // Clear buffer
+  json_buffer_.clear();
+}
+
+void TraceWriter::serialize_reg_info(nlohmann::json& j, const reg_info_t* reg) {
+  if (!reg) return;
+
+  using json = nlohmann::json;
+
+  // Basic fields
+  j["grid_launch_id"] = reg->kernel_launch_id;
+  j["cta"] = {reg->cta_id_x, reg->cta_id_y, reg->cta_id_z};
+  j["warp"] = reg->warp_id;
+  j["opcode_id"] = reg->opcode_id;
+  j["pc"] = reg->pc;
+
+  // CRITICAL: Transpose register array
+  // C layout: reg_vals[thread][reg] → JSON: regs[reg][thread]
+  // This ensures all values for the same register across all threads
+  // are grouped together in the JSON output.
+  json::array_t regs_array;
+  for (int reg_idx = 0; reg_idx < reg->num_regs; reg_idx++) {
+    json::array_t thread_vals;
+    for (int thread = 0; thread < 32; thread++) {
+      thread_vals.push_back(reg->reg_vals[thread][reg_idx]);
+    }
+    regs_array.push_back(thread_vals);
+  }
+  j["regs"] = regs_array;
+
+  // Add unified registers if present
+  if (reg->num_uregs > 0) {
+    json::array_t uregs_array;
+    for (int i = 0; i < reg->num_uregs; i++) {
+      uregs_array.push_back(reg->ureg_vals[i]);
+    }
+    j["uregs"] = uregs_array;
+  }
+}
+
+void TraceWriter::serialize_mem_access(nlohmann::json& j, const mem_access_t* mem) {
+  if (!mem) return;
+
+  // Basic fields
+  j["grid_launch_id"] = mem->kernel_launch_id;
+  j["cta"] = {mem->cta_id_x, mem->cta_id_y, mem->cta_id_z};
+  j["warp"] = mem->warp_id;
+  j["opcode_id"] = mem->opcode_id;
+  j["pc"] = mem->pc;
+
+  // Convert address array (32 addresses)
+  std::vector<uint64_t> addrs(mem->addrs, mem->addrs + 32);
+  j["addrs"] = addrs;
+}
+
+void TraceWriter::serialize_opcode_only(nlohmann::json& j, const opcode_only_t* opcode) {
+  if (!opcode) return;
+
+  // Basic fields (minimal - opcode_only is lightweight)
+  j["grid_launch_id"] = opcode->kernel_launch_id;
+  j["cta"] = {opcode->cta_id_x, opcode->cta_id_y, opcode->cta_id_z};
+  j["warp"] = opcode->warp_id;
+  j["opcode_id"] = opcode->opcode_id;
+  j["pc"] = opcode->pc;
+}
+
+// ============================================================================
+// Format-specific output methods
+// ============================================================================
+
+void TraceWriter::write_text_format(const TraceRecord& record) {
+  if (!file_handle_) return;
+
+  // Dispatch by trace type
+  switch (record.type) {
+    case MSG_TYPE_REG_INFO: {
+      const reg_info_t* ri = record.data.reg_info;
+
+      // Print header line
+      fprintf(file_handle_, "CTX %p - CTA %d,%d,%d - warp %d - %s:\n", record.context, ri->cta_id_x, ri->cta_id_y,
+              ri->cta_id_z, ri->warp_id, record.sass_instruction.c_str());
+
+      // Print register values
+      for (int reg_idx = 0; reg_idx < ri->num_regs; reg_idx++) {
+        fprintf(file_handle_, "  * ");
+        for (int i = 0; i < 32; i++) {
+          fprintf(file_handle_, "Reg%d_T%02d: 0x%08x ", reg_idx, i, ri->reg_vals[i][reg_idx]);
+        }
+        fprintf(file_handle_, "\n");
+      }
+
+      // Print uniform register values (if present)
+      if (ri->num_uregs > 0) {
+        fprintf(file_handle_, "  * UR: ");
+        for (int i = 0; i < ri->num_uregs; i++) {
+          fprintf(file_handle_, "UR%d: 0x%08x ", i, ri->ureg_vals[i]);
+        }
+        fprintf(file_handle_, "\n");
+      }
+
+      fprintf(file_handle_, "\n");
+      break;
+    }
+
+    case MSG_TYPE_MEM_ACCESS: {
+      const mem_access_t* mem = record.data.mem_access;
+
+      // Print header
+      fprintf(file_handle_, "CTX %p - kernel_launch_id %ld - CTA %d,%d,%d - warp %d - PC %ld - %s:\n", record.context,
+              mem->kernel_launch_id, mem->cta_id_x, mem->cta_id_y, mem->cta_id_z, mem->warp_id, mem->pc,
+              record.sass_instruction.c_str());
+
+      // Print memory addresses
+      fprintf(file_handle_, "  Memory Addresses:\n  * ");
+      int printed = 0;
+      for (int i = 0; i < 32; i++) {
+        if (mem->addrs[i] != 0) {
+          fprintf(file_handle_, "T%02d: 0x%016lx ", i, mem->addrs[i]);
+          printed++;
+          if (printed % 4 == 0 && i < 31) {
+            fprintf(file_handle_, "\n    ");
+          }
+        }
+      }
+      fprintf(file_handle_, "\n\n");
+      break;
+    }
+
+    case MSG_TYPE_OPCODE_ONLY: {
+      // Opcode_only typically doesn't output to trace files (only for histogram)
+      // But we can add support if needed
+      break;
+    }
+
+    default:
+      fprintf(stderr, "TraceWriter: Unknown message type %d in text mode\n", record.type);
+      break;
+  }
+
+  fflush(file_handle_);
+}
+
+void TraceWriter::write_json_format(const TraceRecord& record) {
+  try {
+    using json = nlohmann::json;
+    json j;
+
+    // ========== Serialize metadata ==========
+
+    // Type string
+    switch (record.type) {
+      case MSG_TYPE_REG_INFO:
+        j["type"] = "reg_trace";
+        break;
+      case MSG_TYPE_MEM_ACCESS:
+        j["type"] = "mem_trace";
+        break;
+      case MSG_TYPE_OPCODE_ONLY:
+        j["type"] = "opcode_only";
+        break;
+      default:
+        fprintf(stderr, "TraceWriter: Unknown message type %d\n", record.type);
+        return;
+    }
+
+    // Context pointer (as hex string)
+    std::stringstream ss;
+    ss << "0x" << std::hex << reinterpret_cast<uintptr_t>(record.context);
+    j["ctx"] = ss.str();
+
+    // SASS instruction (if available)
+    if (!record.sass_instruction.empty()) {
+      j["sass"] = record.sass_instruction;
+    }
+
+    // Trace index
+    j["trace_index"] = record.trace_index;
+
+    // Timestamp
+    j["timestamp"] = record.timestamp;
+
+    // ========== Serialize data (dispatch by type) ==========
+
+    switch (record.type) {
+      case MSG_TYPE_REG_INFO:
+        serialize_reg_info(j, record.data.reg_info);
+        break;
+      case MSG_TYPE_MEM_ACCESS:
+        serialize_mem_access(j, record.data.mem_access);
+        break;
+      case MSG_TYPE_OPCODE_ONLY:
+        serialize_opcode_only(j, record.data.opcode_only);
+        break;
+    }
+
+    // ========== Buffer and flush ==========
+
+    // Append to JSON buffer (NDJSON format - newline is critical!)
+    json_buffer_ += j.dump() + "\n";
+
+    // Check if buffer threshold reached
+    if (json_buffer_.size() >= buffer_threshold_) {
+      write_uncompressed();
+    }
+
+  } catch (const std::exception& e) {
+    fprintf(stderr, "TraceWriter: JSON error in write_json_format: %s\n", e.what());
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces the `TraceWriter` class to unify trace output across multiple formats, replacing the legacy `trace_lprintf()` approach. It implements support for:
- **Mode 0**: Text format (`.log` files) with improved uniform register (ureg) output
- **Mode 2**: NDJSON format (`.ndjson` files) with structured JSON records
- **Mode 1**: Reserved interface for future compression implementation (PR3)

The implementation provides a clean abstraction layer that handles format-specific serialization while maintaining a unified API for the analysis pipeline.

---

## Key Changes

### 1. New Files (555 lines)

#### `include/trace_writer.h` (232 lines)
**Purpose**: Define unified trace output interface

**Key Components**:
- `TraceRecord` struct: Encapsulates trace data + metadata
  - Original GPU data (`reg_info_t`, `mem_access_t`, `opcode_only_t`)
  - Metadata: `context`, `sass_instruction`, `trace_index`, `timestamp`
- `TraceWriter` class: Format-agnostic trace output
  - `write_trace(const TraceRecord&)`: Single unified API
  - `flush()`: Explicit buffer control
  - Static factory methods: `create_reg_trace()`, `create_mem_trace()`, `create_opcode_trace()`

**Design Rationale**:
- **Separation of concerns**: GPU communication protocol remains unchanged, metadata is added at the host side
- **Atomic writes**: One TraceRecord = one JSON line (for NDJSON mode)
- **Extensibility**: Easy to add new trace types or metadata fields

#### `src/trace_writer.cpp` (323 lines)
**Purpose**: Implement format-specific serialization

**Key Methods**:
- `write_text_format()`: Mode 0 text output
  - Human-readable format matching legacy output
  - **NEW**: Correctly outputs ureg values (bug fix)
  - Format: `"  * UR: UR0: 0x12345678 UR1: 0xabcdef00"`

- `write_json_format()`: Mode 2 NDJSON output
  - One JSON object per line (NDJSON standard)
  - Metadata fields: `type`, `ctx`, `sass`, `trace_index`, `timestamp`
  - Data fields: `grid_launch_id`, `cta`, `warp`, `opcode_id`, `pc`, `regs`, `uregs`

- `serialize_reg_info()`: JSON serialization for register traces
  - **Transpose optimization**: C layout `reg_vals[thread][reg]` → JSON `regs[reg][thread]`
  - **ureg support**: `"uregs": [value0, value1, ...]` when `num_uregs > 0`

**Buffering Strategy**:
- Mode 0 (text): No buffering, direct `fprintf()` + `fflush()` per record
- Mode 2 (JSON): String buffer with 1MB threshold, batch writes for I/O efficiency

---

### 2. Modified Files (~95 lines changed)

#### `include/analysis.h` (+8 lines)
**Changes**:
```cpp
// Forward declaration (line 23)
class TraceWriter;

// ContextState additions (lines 232-239)
struct ContextState {
    // ...
    TraceWriter* trace_writer = nullptr;
    std::unordered_map<uint64_t, uint64_t> trace_index_by_kernel;
};
```

**Purpose**: Add TraceWriter lifecycle management and per-kernel trace indexing to context state.

#### `src/analysis.cu` (~50 lines)
**Changes**:
1. **New includes** (lines 17, 28):
   ```cpp
   #include <chrono>
   #include "trace_writer.h"
   ```

2. **Timestamp helper** (lines 45-56):
   ```cpp
   static inline uint64_t get_timestamp_ns() {
       auto now = std::chrono::high_resolution_clock::now();
       return std::chrono::duration_cast<std::chrono::nanoseconds>(
           now.time_since_epoch()).count();
   }
   ```

3. **Unified trace output** (lines 1117-1141):
   ```cpp
   // OLD: Direct trace_lprintf() calls
   // trace_lprintf("CTX %p - CTA %d,%d,%d - warp %d - %s:\n", ...);
   // for (int reg_idx = 0; reg_idx < ri->num_regs; reg_idx++) { ... }

   // NEW: Unified TraceWriter approach
   if (ctx_state->trace_writer) {
       uint64_t trace_idx = ctx_state->trace_index_by_kernel[ri->kernel_launch_id]++;
       uint64_t timestamp = get_timestamp_ns();
       auto record = TraceRecord::create_reg_trace(ctx, sass_str_cpp, trace_idx, timestamp, ri);
       ctx_state->trace_writer->write_trace(record);
   }
   ```

4. **MEM_ACCESS handling** (lines 1154-1185):
   - **Temporarily commented out**: Old `trace_lprintf()` calls for memory traces
   - **Added TODO**: `TODO(PR#3): Migrate MEM_ACCESS to TraceWriter`
   - **Rationale**: Avoids dependency on removed `log_open_kernel_file()`, will be properly implemented in PR#3

**Impact**: All register traces now go through TraceWriter, enabling consistent metadata and format switching.

#### `src/cutracer.cu` (~30 lines)
**Changes**:
1. **Include TraceWriter** (line 38):
   ```cpp
   #include "trace_writer.h"
   ```

2. **TraceWriter creation** (lines 355-370):
   ```cpp
   // OLD: log_open_kernel_file(ctx, func, kernel_iter_map[func]++);

   // NEW: Create TraceWriter instance
   if (!ctx_state->trace_writer) {
       std::string base_filename = generate_kernel_log_basename(ctx, func, kernel_iter_map[func]++);
       ctx_state->trace_writer = new TraceWriter(base_filename, trace_format_ndjson);
       ctx_state->trace_index_by_kernel[kernel_launch_id - 1] = 0;
       if (verbose) {
           loprintf("Created TraceWriter for mode %d, file: %s\n", trace_format_ndjson, base_filename.c_str());
       }
   }
   ```

3. **Buffer flushing** (lines 389-393, 568-572):
   ```cpp
   // Ensure data is written to disk before kernel exit
   if (ctx_state->trace_writer) {
       ctx_state->trace_writer->flush();
   }
   ```

4. **Cleanup** (lines 568-572):
   ```cpp
   // Proper resource cleanup on context destruction
   if (ctx_state->trace_writer) {
       ctx_state->trace_writer->flush();
       delete ctx_state->trace_writer;
       ctx_state->trace_writer = nullptr;
   }
   ```

**Impact**: TraceWriter lifecycle is properly managed across kernel launches and context destruction.

#### `.gitignore` (+32 lines)
**Changes**:
- Added Python-specific ignore patterns (`__pycache__/`, `*.pyc`, etc.)
- Added `*.ndjson` to ignore trace output files

**Purpose**: Prevent committing generated files and Python cache.

---

## Architecture Design

### Trace Data Flow

```
┌─────────────────────────────────────────────────────────────────┐
│                        GPU Execution                             │
│                                                                   │
│  Instrumented Code → Channel → recv_buffer (analysis.cu)        │
└─────────────────────┬───────────────────────────────────────────┘
                      │
                      ▼
┌─────────────────────────────────────────────────────────────────┐
│                    Host-side Processing                           │
│                                                                   │
│  1. Parse message type (MSG_TYPE_REG_INFO / MEM_ACCESS / etc.)  │
│  2. Lookup SASS instruction from id_to_sass_map                  │
│  3. Generate metadata (trace_index++, timestamp)                 │
│  4. Create TraceRecord                                           │
└─────────────────────┬───────────────────────────────────────────┘
                      │
                      ▼
┌─────────────────────────────────────────────────────────────────┐
│                      TraceWriter                                  │
│                                                                   │
│  write_trace(TraceRecord) → dispatch by trace_mode              │
│                                                                   │
│  ├─ Mode 0: write_text_format()                                 │
│  │           └─ fprintf() + fflush()                            │
│  │                                                                │
│  └─ Mode 2: write_json_format()                                 │
│              ├─ serialize_reg_info() / mem_access() / etc.      │
│              ├─ json_buffer_ += j.dump() + "\n"                 │
│              └─ if (buffer >= 1MB) write_uncompressed()         │
└─────────────────────┬───────────────────────────────────────────┘
                      │
                      ▼
┌─────────────────────────────────────────────────────────────────┐
│                      File Output                                  │
│                                                                   │
│  Mode 0: kernel_<hash>_iter<N>_<name>.log                       │
│  Mode 2: kernel_<hash>_iter<N>_<name>.ndjson                    │
└─────────────────────────────────────────────────────────────────┘
```

### Class Relationships

```
┌───────────────────┐
│   ContextState    │
│                   │
│  + trace_writer ──┼──────┐
│  + trace_index_   │      │
│    by_kernel      │      │
└───────────────────┘      │
                           │ owns
                           │
                           ▼
                  ┌─────────────────┐
                  │   TraceWriter   │
                  │                 │
                  │ + write_trace() │
                  │ + flush()       │
                  └────────┬────────┘
                           │ uses
                           │
                           ▼
                  ┌─────────────────┐
                  │   TraceRecord   │
                  │                 │
                  │ + context       │
                  │ + sass          │
                  │ + trace_index   │
                  │ + timestamp     │
                  │ + data union    │
                  └─────────────────┘
                           │
                    ┌──────┴──────┐
                    ▼             ▼
          ┌──────────────┐  ┌──────────────┐
          │ reg_info_t   │  │ mem_access_t │
          └──────────────┘  └──────────────┘
```

### Metadata Enrichment

TraceRecord adds four metadata fields that don't exist in GPU structs:

| Field | Type | Source | Purpose |
|-------|------|--------|---------|
| `context` | `CUcontext` | `recv_thread_fun()` arg | Debugging, multi-context correlation |
| `sass_instruction` | `std::string` | `id_to_sass_map[func][opcode_id]` | Human-readable disassembly |
| `trace_index` | `uint64_t` | Per-kernel counter | Ordering within kernel execution |
| `timestamp` | `uint64_t` | `std::chrono::high_resolution_clock` | Host-side receive time (nanoseconds) |

---

## Testing

### Manual Testing Commands

```bash
# Build
cd /home/yhao/CUTracer_oss
make clean && make

# Test Mode 0 (text format)
cd tests/vectoradd
TRACE_FORMAT_NDJSON=0 \
CUDA_INJECTION64_PATH=$PWD/../../lib/cutracer.so \
CUTRACER_INSTRUMENT=reg_trace \
./vectoradd

# Verify text output includes ureg
grep -A 3 "UR:" kernel_*.log

# Test Mode 2 (NDJSON format)
TRACE_FORMAT_NDJSON=2 \
CUDA_INJECTION64_PATH=$PWD/../../lib/cutracer.so \
CUTRACER_INSTRUMENT=reg_trace \
./vectoradd

# Verify NDJSON is valid
python3 -m json.tool < kernel_*.ndjson | head -50

# Check for uregs field
grep -o '"uregs"' kernel_*.ndjson | head -5
```

### Expected Results

**Mode 0 Output**:
- File: `kernel_dcd76e64b30810e4_iter0__Z6vecAddPdS_S_i.log`
- Format: Human-readable text with CTX lines
- ureg line appears when `num_uregs > 0`
- File size: ~500KB for vectoradd

**Mode 2 Output**:
- File: `kernel_dcd76e64b30810e4_iter0__Z6vecAddPdS_S_i.ndjson`
- Format: One JSON object per line
- Each object has `type`, `ctx`, `sass`, `trace_index`, `timestamp`, `regs`
- `uregs` field present when `num_uregs > 0`
- File size: ~150KB for vectoradd (uncompressed JSON)

**Validation**: PR#2b will add automated testing with `validate_trace.py` and CI integration.

---

## Known Limitations

### 1. MEM_ACCESS Traces Not Supported Yet
**Issue**: Memory access traces are temporarily disabled (lines 1154-1185 in analysis.cu)

**Reason**:
- Old implementation relied on `log_open_kernel_file()` which has been removed
- TraceWriter needs proper integration point for memory traces

**Workaround**: None (memory tracing temporarily unavailable)

**Fix**: Will be implemented in PR#3 alongside mode 1 compression support

### 2. Mode 1 (Compression) Not Implemented
**Issue**: `TraceWriter` constructor rejects `trace_mode=1`

**Reason**: Compression requires additional dependencies and testing

**Workaround**: Use mode 2 (uncompressed NDJSON) for now

**Fix**: PR#3 will implement Zstd compression for mode 1

### 3. No Cross-Format Validation Yet
**Issue**: No automated testing to verify mode 0 and mode 2 produce equivalent data

**Workaround**: Manual comparison using grep/jq

**Fix**: PR#2b will add `validate_trace.py` with cross-format comparison

---

## Performance Considerations

### Mode 0 (Text)
- **Strategy**: Unbuffered, immediate writes
- **Pros**: Simple, data visible immediately
- **Cons**: More `fprintf()` system calls
- **Benchmark**: ~500KB output for vectoradd, negligible overhead

### Mode 2 (NDJSON)
- **Strategy**: Buffered writes (1MB threshold)
- **Pros**: Fewer I/O operations, better throughput
- **Cons**: Data visible only after flush
- **Benchmark**: ~150KB output for vectoradd
- **Space savings**: ~70% vs mode 0 (before compression)

### Memory Usage
- **TraceWriter**: ~1MB string buffer per context (mode 2 only)
- **TraceRecord**: Stack allocated, zero heap allocation
- **JSON serialization**: nlohmann::json uses dynamic allocation but is short-lived

---

## Related Work

- **PR#1**: NDJSON infrastructure setup (nlohmann/json, TRACE_FORMAT_NDJSON env var)
- **PR#2b**: Unit tests and validation tools (next)
- **PR#3**: Mode 1 compression + MEM_ACCESS migration (planned)
- **PR#4**: Performance optimization and benchmarking (planned)
- **PR#5**: Documentation and migration guide (planned)


