### PR TITLE
Improve Zstd compression: max level and standard extension

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -239,7 +239,7 @@ test_trace_formats() {
   local cross_validation_status="pending"
 
   # Clean up old trace files
-  rm -f *.log *.ndjson *.ndjson.zstd
+  rm -f *.log *.ndjson *.ndjson.zst
 
   # ===== Test Mode 0 (Text Format) =====
   echo ""
@@ -349,8 +349,8 @@ test_trace_formats() {
   echo ""
   echo "  📦 Testing Mode 1 (NDJSON + Zstd)..."
 
-  # Clean old zstd files
-  rm -f *.ndjson.zstd mode1_decompressed.ndjson
+  # Clean old zst files
+  rm -f *.ndjson.zst mode1_decompressed.ndjson
 
   if ! TRACE_FORMAT_NDJSON=1 \
        CUDA_INJECTION64_PATH="$PROJECT_ROOT/lib/cutracer.so" \
@@ -359,10 +359,10 @@ test_trace_formats() {
     echo "    ❌ Mode 1 execution failed"
     mode1_status="failed"
   else
-    # Find generated .ndjson.zstd file
-    mode1_file=$(ls -1t kernel_*vecAdd*.ndjson.zstd 2>/dev/null | head -n 1)
+    # Find generated .ndjson.zst file
+    mode1_file=$(ls -1t kernel_*vecAdd*.ndjson.zst 2>/dev/null | head -n 1)
     if [ -z "$mode1_file" ]; then
-      echo "    ❌ No .ndjson.zstd file generated"
+      echo "    ❌ No .ndjson.zst file generated"
       mode1_status="failed"
     else
       echo "    ✅ Found: $mode1_file"

--- a/.gitignore
+++ b/.gitignore
@@ -109,4 +109,5 @@ compile_commands.json
 *.ptx
 *.sass
 *.ndjson
+*.zst
 *.zstd

--- a/include/trace_writer.h
+++ b/include/trace_writer.h
@@ -137,7 +137,7 @@ struct TraceRecord {
  *
  * Unified writer supporting three output modes:
  * - Mode 0: Text format (legacy .log files)
- * - Mode 1: NDJSON + Zstd compression (.ndjson.zstd)
+ * - Mode 1: NDJSON + Zstd compression (.ndjson.zst)
  * - Mode 2: NDJSON uncompressed (.ndjson)
  *
  * Key features:
@@ -183,7 +183,7 @@ class TraceWriter {
    * @brief Write a trace record to output.
    *
    * Mode 0: Formats as text and writes to .log file
-   * Mode 1/2: Serializes to JSON and writes to .ndjson[.zstd] file
+   * Mode 1/2: Serializes to JSON and writes to .ndjson[.zst] file
    *
    * @param record Complete trace record with all information
    * @return true if successful, false on error
@@ -223,7 +223,7 @@ class TraceWriter {
   /**
    * @brief Compress and write buffer to file (mode 1).
    *
-   * Compresses json_buffer_ using Zstd and writes to .ndjson.zstd file.
+   * Compresses json_buffer_ using Zstd and writes to .ndjson.zst file.
    * Each flush creates an independent Zstd frame for incremental writing.
    */
   void write_compressed();

--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,7 @@ CUDA_INJECTION64_PATH=~/CUTracer/lib/cutracer.so \
 -   `INSTR_BEGIN`, `INSTR_END`: static instruction index gate during instrumentation
 -   `TOOL_VERBOSE`: 0/1/2
 -   `TRACE_FORMAT_NDJSON`: trace output format
-    -   **1** (default): NDJSON+Zstd compressed (`.ndjson.zstd`, ~12x compression, 92% space savings)
+    -   **1** (default): NDJSON+Zstd compressed (`.ndjson.zst`, ~12x compression, 92% space savings)
     -   0: Plain text (`.log`, legacy format, verbose)
     -   2: NDJSON uncompressed (`.ndjson`, for debugging)
 

--- a/src/trace_writer.cpp
+++ b/src/trace_writer.cpp
@@ -23,7 +23,7 @@ TraceWriter::TraceWriter(const std::string& filename, int trace_mode, size_t buf
       trace_mode_(trace_mode),
       enabled_(true),
       zstd_ctx_(nullptr),
-      compression_level_(9) {  // Default compression level 9 (balanced)
+      compression_level_(22) {  // Maximum compression level for best compression ratio
 
   // Validate trace mode
   if (trace_mode < 0 || trace_mode > 2) {
@@ -43,7 +43,7 @@ TraceWriter::TraceWriter(const std::string& filename, int trace_mode, size_t buf
 
   } else if (trace_mode == 1) {
     // Mode 1: NDJSON + Zstd compression
-    actual_filename = filename + ".ndjson.zstd";
+    actual_filename = filename + ".ndjson.zst";
     open_mode = "ab";  // Append binary mode (required for compressed data)
 
     // Initialize Zstd compression context


### PR DESCRIPTION
## Summary

This PR improves CUTracer's trace compression by maximizing compression ratio and adopting the standard Zstandard file extension.

## Motivation

- **Storage efficiency**: Current compression level (9) is balanced for speed/size, but CUTracer's async compression model can afford higher compression at no user-perceived cost
- **Standards compliance**: `.zstd` is non-standard; `.zst` is the official Zstandard extension, ensuring better tool compatibility

## Changes

### 1. Maximize Compression Ratio
- Increase Zstd compression level from 9 → 22 (maximum)
- Updates `src/trace_writer.cpp` compression settings
- Trade speed for smaller trace files (acceptable since compression is asynchronous)

### 2. Adopt Standard File Extension
- Change trace file extension: `.ndjson.zstd` → `.ndjson.zst`
- Update all references across:
  - Source code (`src/trace_writer.cpp`)
  - CI test scripts (`.ci/run_tests.sh`)
  - Documentation (`readme.md`)
  - Code comments (`include/trace_writer.h`)
  - Git ignore rules (`.gitignore`)

## Impact

- **Generated files**: All compressed traces now use `.ndjson.zst` format
- **CI/CD**: Test suite updated to handle new extension
- **Backward compatibility**: `.gitignore` includes both `.zst` and `.zstd` for transition period
- **Compression improvement**: Expected 15-25% additional space savings with level 22 vs level 9

## Testing

All existing tests pass with updated file extensions:
- Unit tests for trace writer
- Integration tests (vectoradd, proton, hang detection)
- Format validation (mode 0/1/2 cross-validation)
