### PR TITLE
Refactor Instrumentation Interface with OperandLists Structure

### DIFF
--- a/include/instrument.h
+++ b/include/instrument.h
@@ -21,6 +21,19 @@ enum class InstrumentType {
 };
 
 /**
+ * @brief Structure to hold operand information for instrumentation
+ *
+ * This structure groups operand data needed for instrumentation,
+ * making it easy to extend support for additional operand types without
+ * changing function signatures.
+ */
+struct OperandLists {
+  std::vector<int> reg_nums;   // Regular register numbers
+  std::vector<int> ureg_nums;  // Uniform register numbers
+  // Future: add support for other types like pred_nums, generic_vals, etc.
+};
+
+/**
  * @brief Insert lightweight opcode-only instrumentation for instruction histogram analysis
  *
  * This is optimized for Proton instruction statistic analysis where only opcode
@@ -40,11 +53,9 @@ void instrument_opcode_only(Instr* instr, int opcode_id, CTXstate* ctx_state);
  * @param instr The instruction to instrument
  * @param opcode_id The opcode identifier for this instruction
  * @param ctx_state The context state containing channel information
- * @param reg_num_list List of register numbers to trace
- * @param ureg_num_list List of uniform register numbers to trace
+ * @param operands Structure containing all operand information (reg, ureg, etc.)
  */
-void instrument_register_trace(Instr* instr, int opcode_id, CTXstate* ctx_state, const std::vector<int>& reg_num_list,
-                               const std::vector<int>& ureg_num_list);
+void instrument_register_trace(Instr* instr, int opcode_id, CTXstate* ctx_state, const OperandLists& operands);
 
 /**
  * @brief Insert memory access tracing instrumentation

--- a/src/instrument.cu
+++ b/src/instrument.cu
@@ -58,8 +58,7 @@ void instrument_opcode_only(Instr* instr, int opcode_id, CTXstate* ctx_state) {
  *  - **Refactoring**: Encapsulated the logic into this dedicated function,
  *    separating it from the main instruction iteration loop in `cutracer.cu`.
  */
-void instrument_register_trace(Instr* instr, int opcode_id, CTXstate* ctx_state, const std::vector<int>& reg_num_list,
-                               const std::vector<int>& ureg_num_list) {
+void instrument_register_trace(Instr* instr, int opcode_id, CTXstate* ctx_state, const OperandLists& operands) {
   /* insert call to the instrumentation function with its arguments */
   nvbit_insert_call(instr, "instrument_reg_val", IPOINT_BEFORE);
   /* guard predicate value */
@@ -75,15 +74,15 @@ void instrument_register_trace(Instr* instr, int opcode_id, CTXstate* ctx_state,
   /* add instruction offset */
   nvbit_add_call_arg_const_val64(instr, instr->getOffset());
   /* how many register values are passed next */
-  nvbit_add_call_arg_const_val32(instr, reg_num_list.size());
-  nvbit_add_call_arg_const_val32(instr, ureg_num_list.size());
+  nvbit_add_call_arg_const_val32(instr, operands.reg_nums.size());
+  nvbit_add_call_arg_const_val32(instr, operands.ureg_nums.size());
 
-  for (int num : reg_num_list) {
+  for (int num : operands.reg_nums) {
     /* last parameter tells it is a variadic parameter passed to
      * the instrument function record_reg_val() */
     nvbit_add_call_arg_reg_val(instr, num, true);
   }
-  for (int num : ureg_num_list) {
+  for (int num : operands.ureg_nums) {
     nvbit_add_call_arg_ureg_val(instr, num, true);
   }
 }


### PR DESCRIPTION
## Overview

Refactors the instrumentation interface to use a unified `OperandLists` structure instead of separate vector parameters. This improves maintainability and prepares for adding GENERIC and PRED register type support.

## Motivation

The current interface passes operand information via separate `reg_num_list` and `ureg_num_list` vectors, which:
- Creates unstable function signatures when adding new operand types
- Leads to verbose function calls with multiple parameters

## Changes

**Added `OperandLists` struct** (`include/instrument.h`):
```cpp
struct OperandLists {
  std::vector<int> reg_nums;   // Regular register numbers
  std::vector<int> ureg_nums;  // Uniform register numbers
  // Future: pred_nums, generic_vals, etc.
};
```

**Updated function signature**:
```cpp
// Before
void instrument_register_trace(..., const std::vector<int>& reg_num_list,
                               const std::vector<int>& ureg_num_list);
// After
void instrument_register_trace(..., const OperandLists& operands);
```

**Updated call sites** in `src/cutracer.cu` and `src/instrument.cu` to use the new structure.

## Benefits

- Stable function signature for future extensions (GENERIC, PRED registers)
- Better code organization with operands grouped in one structure
- Easier to extend without breaking API

## Impact

- No breaking changes (internal refactoring only)
- No performance impact
- All existing tests pass unchanged
