### PR TITLE
[python] PR-1: Add Python Project Configuration

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -26,6 +26,8 @@ dev = [
     "mypy>=1.0.0",
     "black>=22.0.0",
     "ruff>=0.1.0",
+    "ufmt>=2.0.0",
+    "usort>=1.0.0",
 ]
 
 [project.urls]
@@ -67,32 +69,7 @@ first_party_detection = false
 version_scheme = "guess-next-dev"
 local_scheme = "no-local-version"
 
-[tool.mypy]
-python_version = "3.10"
-warn_return_any = true
-warn_unused_configs = true
-disallow_untyped_defs = false
-ignore_missing_imports = true
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 addopts = "-v --color=yes"
-
-[tool.ruff]
-line-length = 100
-target-version = "py310"
-select = [
-    "E",  # pycodestyle errors
-    "W",  # pycodestyle warnings
-    "F",  # pyflakes
-    "I",  # isort
-    "B",  # flake8-bugbear
-    "C4", # flake8-comprehensions
-]
-ignore = [
-    "E501", # line too long (handled by black)
-]
-
-[tool.ruff.per-file-ignores]
-"__init__.py" = ["F401"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,98 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+[build-system]
+requires = ["setuptools>=64", "wheel", "setuptools-scm>=8.0.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cutracer"
+dynamic = ["version"]
+description = "Python tools for CUTracer trace validation and analysis"
+requires-python = ">=3.10"
+authors = [
+    {name = "Yueming Hao", email = "yueming@meta.com"}
+]
+readme = "README.md"
+license = "MIT"
+
+dependencies = [
+    "jsonschema>=4.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+    "mypy>=1.0.0",
+    "black>=22.0.0",
+    "ruff>=0.1.0",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/facebookresearch/CUTracer"
+"Bug Tracker" = "https://github.com/facebookresearch/CUTracer/issues"
+
+# Note: CLI entry points can be added when cutracer.cli module is implemented
+# [project.scripts]
+# validate-trace = "cutracer.cli:main"
+
+[tool.black]
+line-length = 88
+target-version = ["py310"]
+exclude = '''
+/(
+    \.git
+  | \.mypy_cache
+  | \.pytest_cache
+  | \.venv
+  | build
+  | dist
+)/
+'''
+
+[tool.setuptools.packages.find]
+include = ["cutracer*"]
+
+[tool.setuptools.package-data]
+"cutracer.validation.schemas" = ["*.json"]
+
+[tool.ufmt]
+formatter = "black"
+sorter = "usort"
+
+[tool.usort]
+first_party_detection = false
+
+[tool.setuptools_scm]
+version_scheme = "guess-next-dev"
+local_scheme = "no-local-version"
+
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+addopts = "-v --color=yes"
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+select = [
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+    "F",  # pyflakes
+    "I",  # isort
+    "B",  # flake8-bugbear
+    "C4", # flake8-comprehensions
+]
+ignore = [
+    "E501", # line too long (handled by black)
+]
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -66,6 +66,7 @@ sorter = "usort"
 first_party_detection = false
 
 [tool.setuptools_scm]
+root = ".."
 version_scheme = "guess-next-dev"
 local_scheme = "no-local-version"
 


### PR DESCRIPTION

## Summary

Add `pyproject.toml` to establish the Python project structure for CUTracer validation module.

## Changes

- `python/pyproject.toml` (+98 lines)

## Details

- Python 3.10+ requirement
- MIT license
- Runtime dependency: `jsonschema>=4.0.0`
- Dev dependencies: pytest, mypy, black, ruff
- Tool configurations for linting and testing

## Test Plan

Configuration only, no executable code. Full testing will be available after PR-7 (module exports).

