### PR TITLE
[python]PR-2: Add JSON Schema Files

### DIFF
--- a/python/cutracer/validation/schemas/__init__.py
+++ b/python/cutracer/validation/schemas/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+CUTracer JSON Schema files.
+
+This package contains JSON Schema definition files for validating
+CUTracer trace records.
+"""

--- a/python/cutracer/validation/schemas/mem_trace.schema.json
+++ b/python/cutracer/validation/schemas/mem_trace.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/facebookresearch/CUTracer/schemas/mem_trace.schema.json",
+  "title": "CUTracer Memory Access Trace Record",
+  "description": "Schema for MSG_TYPE_MEM_ACCESS (type='mem_trace') - records memory addresses accessed by each thread",
+  "type": "object",
+  "required": [
+    "type",
+    "ctx",
+    "sass",
+    "trace_index",
+    "timestamp",
+    "grid_launch_id",
+    "cta",
+    "warp",
+    "opcode_id",
+    "pc",
+    "addrs"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["mem_trace"],
+      "description": "Message type identifier"
+    },
+    "ctx": {
+      "type": "string",
+      "pattern": "^0x[0-9a-fA-F]+$",
+      "description": "CUDA context pointer in hex format"
+    },
+    "sass": {
+      "type": "string",
+      "minLength": 1,
+      "description": "SASS instruction string"
+    },
+    "trace_index": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Sequential index of this trace record"
+    },
+    "timestamp": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Timestamp when trace was captured"
+    },
+    "grid_launch_id": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Kernel launch identifier"
+    },
+    "cta": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "minItems": 3,
+      "maxItems": 3,
+      "description": "CTA (Cooperative Thread Array) coordinates [x, y, z]"
+    },
+    "warp": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Warp ID within the CTA"
+    },
+    "opcode_id": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Opcode identifier"
+    },
+    "pc": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Program counter value"
+    },
+    "addrs": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "minItems": 32,
+      "maxItems": 32,
+      "description": "Memory addresses accessed by each of the 32 threads in the warp"
+    }
+  },
+  "additionalProperties": false
+}

--- a/python/cutracer/validation/schemas/opcode_only.schema.json
+++ b/python/cutracer/validation/schemas/opcode_only.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/facebookresearch/CUTracer/schemas/opcode_only.schema.json",
+  "title": "CUTracer Opcode Only Trace Record",
+  "description": "Schema for MSG_TYPE_OPCODE_ONLY (type='opcode_only') - records only instruction execution without data",
+  "type": "object",
+  "required": [
+    "type",
+    "ctx",
+    "sass",
+    "trace_index",
+    "timestamp",
+    "grid_launch_id",
+    "cta",
+    "warp",
+    "opcode_id",
+    "pc"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["opcode_only"],
+      "description": "Message type identifier"
+    },
+    "ctx": {
+      "type": "string",
+      "pattern": "^0x[0-9a-fA-F]+$",
+      "description": "CUDA context pointer in hex format"
+    },
+    "sass": {
+      "type": "string",
+      "minLength": 1,
+      "description": "SASS instruction string"
+    },
+    "trace_index": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Sequential index of this trace record"
+    },
+    "timestamp": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Timestamp when trace was captured"
+    },
+    "grid_launch_id": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Kernel launch identifier"
+    },
+    "cta": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "minItems": 3,
+      "maxItems": 3,
+      "description": "CTA (Cooperative Thread Array) coordinates [x, y, z]"
+    },
+    "warp": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Warp ID within the CTA"
+    },
+    "opcode_id": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Opcode identifier"
+    },
+    "pc": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Program counter value"
+    }
+  },
+  "additionalProperties": false
+}

--- a/python/cutracer/validation/schemas/reg_trace.schema.json
+++ b/python/cutracer/validation/schemas/reg_trace.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/facebookresearch/CUTracer/schemas/reg_trace.schema.json",
+  "title": "CUTracer Register Trace Record",
+  "description": "Schema for MSG_TYPE_REG_INFO (type='reg_trace') - records register values for each warp",
+  "type": "object",
+  "required": [
+    "type",
+    "ctx",
+    "sass",
+    "trace_index",
+    "timestamp",
+    "grid_launch_id",
+    "cta",
+    "warp",
+    "opcode_id",
+    "pc",
+    "regs"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["reg_trace"],
+      "description": "Message type identifier"
+    },
+    "ctx": {
+      "type": "string",
+      "pattern": "^0x[0-9a-fA-F]+$",
+      "description": "CUDA context pointer in hex format"
+    },
+    "sass": {
+      "type": "string",
+      "minLength": 1,
+      "description": "SASS instruction string"
+    },
+    "trace_index": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Sequential index of this trace record"
+    },
+    "timestamp": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Timestamp when trace was captured"
+    },
+    "grid_launch_id": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Kernel launch identifier"
+    },
+    "cta": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "minItems": 3,
+      "maxItems": 3,
+      "description": "CTA (Cooperative Thread Array) coordinates [x, y, z]"
+    },
+    "warp": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Warp ID within the CTA"
+    },
+    "opcode_id": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Opcode identifier"
+    },
+    "pc": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Program counter value"
+    },
+    "regs": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "integer"
+        },
+        "minItems": 32,
+        "maxItems": 32
+      },
+      "description": "2D array of register values [reg_index][thread_index]"
+    },
+    "uregs": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Optional uniform register values"
+    }
+  },
+  "additionalProperties": false
+}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -26,6 +26,8 @@ dev = [
     "mypy>=1.0.0",
     "black>=22.0.0",
     "ruff>=0.1.0",
+    "ufmt>=2.0.0",
+    "usort>=1.0.0",
 ]
 
 [project.urls]
@@ -67,32 +69,7 @@ first_party_detection = false
 version_scheme = "guess-next-dev"
 local_scheme = "no-local-version"
 
-[tool.mypy]
-python_version = "3.10"
-warn_return_any = true
-warn_unused_configs = true
-disallow_untyped_defs = false
-ignore_missing_imports = true
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 addopts = "-v --color=yes"
-
-[tool.ruff]
-line-length = 100
-target-version = "py310"
-select = [
-    "E",  # pycodestyle errors
-    "W",  # pycodestyle warnings
-    "F",  # pyflakes
-    "I",  # isort
-    "B",  # flake8-bugbear
-    "C4", # flake8-comprehensions
-]
-ignore = [
-    "E501", # line too long (handled by black)
-]
-
-[tool.ruff.per-file-ignores]
-"__init__.py" = ["F401"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,98 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+[build-system]
+requires = ["setuptools>=64", "wheel", "setuptools-scm>=8.0.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cutracer"
+dynamic = ["version"]
+description = "Python tools for CUTracer trace validation and analysis"
+requires-python = ">=3.10"
+authors = [
+    {name = "Yueming Hao", email = "yueming@meta.com"}
+]
+readme = "README.md"
+license = "MIT"
+
+dependencies = [
+    "jsonschema>=4.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+    "mypy>=1.0.0",
+    "black>=22.0.0",
+    "ruff>=0.1.0",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/facebookresearch/CUTracer"
+"Bug Tracker" = "https://github.com/facebookresearch/CUTracer/issues"
+
+# Note: CLI entry points can be added when cutracer.cli module is implemented
+# [project.scripts]
+# validate-trace = "cutracer.cli:main"
+
+[tool.black]
+line-length = 88
+target-version = ["py310"]
+exclude = '''
+/(
+    \.git
+  | \.mypy_cache
+  | \.pytest_cache
+  | \.venv
+  | build
+  | dist
+)/
+'''
+
+[tool.setuptools.packages.find]
+include = ["cutracer*"]
+
+[tool.setuptools.package-data]
+"cutracer.validation.schemas" = ["*.json"]
+
+[tool.ufmt]
+formatter = "black"
+sorter = "usort"
+
+[tool.usort]
+first_party_detection = false
+
+[tool.setuptools_scm]
+version_scheme = "guess-next-dev"
+local_scheme = "no-local-version"
+
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+addopts = "-v --color=yes"
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+select = [
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+    "F",  # pyflakes
+    "I",  # isort
+    "B",  # flake8-bugbear
+    "C4", # flake8-comprehensions
+]
+ignore = [
+    "E501", # line too long (handled by black)
+]
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -66,6 +66,7 @@ sorter = "usort"
 first_party_detection = false
 
 [tool.setuptools_scm]
+root = ".."
 version_scheme = "guess-next-dev"
 local_scheme = "no-local-version"
 


### PR DESCRIPTION

**Branch**: `findhao/python-validation-pr2-json-schemas`
**Base**: `findhao/python-validation-pr1-project-config`

## Summary

Add JSON Schema definition files for validating CUTracer trace records.

## Changes

- `python/cutracer/validation/schemas/__init__.py` (+8 lines)
- `python/cutracer/validation/schemas/reg_trace.schema.json` (+97 lines)
- `python/cutracer/validation/schemas/mem_trace.schema.json` (+87 lines)
- `python/cutracer/validation/schemas/opcode_only.schema.json` (+77 lines)

**Total**: +269 lines

## Details

Three JSON Schema files defining the expected structure of NDJSON trace records:

| Schema | Purpose |
|--------|---------|
| `reg_trace.schema.json` | Register trace format with full register values |
| `mem_trace.schema.json` | Memory access trace format |
| `opcode_only.schema.json` | Lightweight opcode-only trace format |

## Test Plan

Schema files are data definitions. Validation tests will be added in PR-8 after the schema loader (PR-3) is implemented.


