### PR TITLE
[python]PR-5: Add JSON Trace Validator

### DIFF
--- a/python/cutracer/validation/json_validator.py
+++ b/python/cutracer/validation/json_validator.py
@@ -1,0 +1,254 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+JSON validator for CUTracer NDJSON trace files.
+
+This module provides functions to validate NDJSON trace files produced by
+CUTracer for syntax correctness and schema compliance.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import jsonschema
+
+from .schema_loader import SCHEMAS_BY_TYPE
+
+
+class ValidationError(Exception):
+    """Exception raised for validation errors."""
+
+    pass
+
+
+def validate_json_syntax(filepath: Path) -> Tuple[int, List[str]]:
+    """
+    Validate JSON syntax line-by-line for NDJSON file.
+
+    Args:
+        filepath: Path to NDJSON trace file
+
+    Returns:
+        Tuple of (valid_count, errors) where:
+            - valid_count: Number of valid JSON lines parsed
+            - errors: List of error messages with line numbers
+
+    Raises:
+        FileNotFoundError: If file does not exist
+    """
+    if not filepath.exists():
+        raise FileNotFoundError(f"File not found: {filepath}")
+
+    valid_count = 0
+    errors: List[str] = []
+
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            for line_num, line in enumerate(f, start=1):
+                line = line.strip()
+                if not line:
+                    continue
+
+                try:
+                    json.loads(line)
+                    valid_count += 1
+                except json.JSONDecodeError as e:
+                    errors.append(f"Line {line_num}: JSON decode error - {e.msg}")
+
+    except Exception as e:
+        errors.append(f"File reading error: {str(e)}")
+
+    return valid_count, errors
+
+
+def validate_json_schema(
+    filepath: Path,
+    message_type: str = "reg_trace",
+    max_errors: int = 10,
+    allow_mixed_types: bool = False,
+) -> bool:
+    """
+    Validate JSON schema against TraceRecord definition.
+
+    Args:
+        filepath: Path to NDJSON trace file
+        message_type: Expected message type (default: "reg_trace")
+        max_errors: Maximum number of schema errors to collect (default: 10)
+        allow_mixed_types: If True, validate each record against its own schema
+                          based on the 'type' field. If False, all records must
+                          match the specified message_type. (default: False)
+
+    Returns:
+        True if all records pass schema validation
+
+    Raises:
+        ValidationError: If schema validation fails (includes detailed errors)
+        FileNotFoundError: If file does not exist
+        ValueError: If message_type is not recognized
+    """
+    if not filepath.exists():
+        raise FileNotFoundError(f"File not found: {filepath}")
+
+    if message_type not in SCHEMAS_BY_TYPE:
+        valid_types = ", ".join(SCHEMAS_BY_TYPE.keys())
+        raise ValueError(
+            f"Unknown message type: {message_type}. Valid types: {valid_types}"
+        )
+
+    # Pre-create validators for all types if allowing mixed types
+    validators = {
+        msg_type: jsonschema.Draft7Validator(schema)
+        for msg_type, schema in SCHEMAS_BY_TYPE.items()
+    }
+    default_validator = validators[message_type]
+
+    errors: List[str] = []
+    line_num = 0
+
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            for line_num, line in enumerate(f, start=1):
+                line = line.strip()
+                if not line:
+                    continue
+
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as e:
+                    errors.append(f"Line {line_num}: JSON syntax error - {e.msg}")
+                    if len(errors) >= max_errors:
+                        break
+                    continue
+
+                # Get the record's type
+                record_type = record.get("type", "")
+
+                if allow_mixed_types:
+                    # Validate against the appropriate schema for this record's type
+                    if record_type not in SCHEMAS_BY_TYPE:
+                        errors.append(
+                            f"Line {line_num}: Unknown message type '{record_type}'"
+                        )
+                        if len(errors) >= max_errors:
+                            break
+                        continue
+                    validator = validators[record_type]
+                else:
+                    # Check if type field matches expected type
+                    if record_type != message_type:
+                        errors.append(
+                            f"Line {line_num}: Expected type '{message_type}', "
+                            f"got '{record_type}'"
+                        )
+                        if len(errors) >= max_errors:
+                            break
+                        continue
+                    validator = default_validator
+
+                # Validate against schema
+                validation_errors = list(validator.iter_errors(record))
+                if validation_errors:
+                    for error in validation_errors[
+                        :3
+                    ]:  # Show first 3 errors per record
+                        field_path = ".".join(str(p) for p in error.path)
+                        errors.append(
+                            f"Line {line_num}: Schema error at '{field_path}': "
+                            f"{error.message}"
+                        )
+                    if len(errors) >= max_errors:
+                        break
+
+    except Exception as e:
+        errors.append(f"File reading error: {str(e)}")
+
+    if errors:
+        error_summary = "\n".join(errors)
+        if len(errors) >= max_errors:
+            error_summary += f"\n... (showing first {max_errors} errors)"
+        raise ValidationError(f"Schema validation failed:\n{error_summary}")
+
+    return True
+
+
+def validate_json_trace(filepath: Path) -> Dict[str, Any]:
+    """
+    Complete validation of NDJSON trace file.
+
+    Performs both syntax and schema validation, with auto-detection of
+    message type from the first record.
+
+    Args:
+        filepath: Path to NDJSON trace file
+
+    Returns:
+        Dictionary containing:
+            - valid: bool - Whether validation passed
+            - record_count: int - Number of valid records
+            - file_size: int - File size in bytes
+            - message_type: str - Detected message type
+            - errors: List[str] - Error messages (empty if valid)
+
+    Raises:
+        FileNotFoundError: If file does not exist
+    """
+    if not filepath.exists():
+        raise FileNotFoundError(f"File not found: {filepath}")
+
+    result: Dict[str, Any] = {
+        "valid": False,
+        "record_count": 0,
+        "file_size": filepath.stat().st_size,
+        "message_type": None,
+        "errors": [],
+    }
+
+    # Step 1: Validate syntax
+    try:
+        valid_count, syntax_errors = validate_json_syntax(filepath)
+        result["record_count"] = valid_count
+
+        if syntax_errors:
+            result["errors"].extend(syntax_errors)
+            return result
+
+        if valid_count == 0:
+            result["errors"].append("No valid JSON records found in file")
+            return result
+
+    except Exception as e:
+        result["errors"].append(f"Syntax validation error: {str(e)}")
+        return result
+
+    # Step 2: Auto-detect message type from first record
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    first_record = json.loads(line)
+                    message_type = first_record.get("type")
+                    if message_type not in SCHEMAS_BY_TYPE:
+                        result["errors"].append(
+                            f"Unknown message type in file: {message_type}"
+                        )
+                        return result
+                    result["message_type"] = message_type
+                    break
+    except Exception as e:
+        result["errors"].append(f"Failed to detect message type: {str(e)}")
+        return result
+
+    # Step 3: Validate schema (allow mixed types since trace files often contain multiple record types)
+    try:
+        validate_json_schema(
+            filepath, message_type=result["message_type"], allow_mixed_types=True
+        )
+        result["valid"] = True
+    except ValidationError as e:
+        result["errors"].append(str(e))
+    except Exception as e:
+        result["errors"].append(f"Schema validation error: {str(e)}")
+
+    return result

--- a/python/cutracer/validation/text_validator.py
+++ b/python/cutracer/validation/text_validator.py
@@ -1,0 +1,238 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Text format validator for CUTracer text trace files.
+
+This module provides functions to validate text-format trace files (mode 0)
+produced by CUTracer for format compliance.
+"""
+
+import re
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+class ValidationError(Exception):
+    """Exception raised for validation errors."""
+
+    pass
+
+
+# Regex patterns for validating text trace format
+# Pattern for header line (MSG_TYPE_REG_INFO)
+REG_INFO_HEADER_PATTERN = re.compile(
+    r"^CTX\s+0x[0-9a-fA-F]+\s+-\s+CTA\s+\d+,\d+,\d+\s+-\s+warp\s+\d+\s+-\s+.+:$"
+)
+
+# Pattern for register value line
+REGISTER_VALUE_PATTERN = re.compile(r"^\s+\*\s+(Reg\d+_T\d+:\s+0x[0-9a-fA-F]+\s*)+$")
+
+# Pattern for memory access header (MSG_TYPE_MEM_ACCESS)
+MEM_ACCESS_HEADER_PATTERN = re.compile(
+    r"^CTX\s+0x[0-9a-fA-F]+\s+-\s+kernel_launch_id\s+\d+\s+-\s+CTA\s+\d+,\d+,\d+\s+-\s+"
+    r"warp\s+\d+\s+-\s+PC\s+\d+\s+-\s+.+:$"
+)
+
+# Pattern for memory addresses
+MEMORY_ADDRESS_PATTERN = re.compile(r"T\d+:\s+0x[0-9a-fA-F]{16}")
+
+
+def validate_text_format(filepath: Path) -> bool:
+    """
+    Validate text format of trace file.
+
+    Checks for proper structure:
+    - Header lines with CTX, CTA, warp, and SASS instruction
+    - Register value lines or memory address lines
+    - Proper hex formatting
+
+    Args:
+        filepath: Path to text trace file
+
+    Returns:
+        True if format is valid
+
+    Raises:
+        ValidationError: If format validation fails
+        FileNotFoundError: If file does not exist
+    """
+    if not filepath.exists():
+        raise FileNotFoundError(f"File not found: {filepath}")
+
+    errors: List[str] = []
+    line_num = 0
+    last_was_header = False
+
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            for line_num, line in enumerate(f, start=1):
+                # Skip empty lines
+                if not line.strip():
+                    last_was_header = False
+                    continue
+
+                # Check if this is a header line
+                is_reg_header = REG_INFO_HEADER_PATTERN.match(line)
+                is_mem_header = MEM_ACCESS_HEADER_PATTERN.match(line)
+
+                if is_reg_header or is_mem_header:
+                    last_was_header = True
+                    continue
+
+                # Check if this is a register value line
+                if REGISTER_VALUE_PATTERN.match(line):
+                    if not last_was_header:
+                        errors.append(
+                            f"Line {line_num}: Register values without header"
+                        )
+                    continue
+
+                # Check if this line contains memory addresses
+                if "Memory Addresses:" in line:
+                    continue
+
+                if MEMORY_ADDRESS_PATTERN.search(line):
+                    continue
+
+                # If we get here, the line doesn't match any expected pattern
+                # Only report if it's not whitespace-only or a separator
+                if line.strip() and not line.strip().startswith("*"):
+                    errors.append(f"Line {line_num}: Unrecognized format: {line[:50]}")
+
+    except Exception as e:
+        errors.append(f"File reading error: {str(e)}")
+
+    if errors:
+        max_errors = 10
+        error_summary = "\n".join(errors[:max_errors])
+        if len(errors) > max_errors:
+            error_summary += (
+                f"\n... (showing first {max_errors} of {len(errors)} errors)"
+            )
+        raise ValidationError(f"Text format validation failed:\n{error_summary}")
+
+    return True
+
+
+def validate_text_trace(filepath: Path) -> Dict[str, Any]:
+    """
+    Complete validation of text trace file.
+
+    Performs format validation and collects file statistics.
+
+    Args:
+        filepath: Path to text trace file
+
+    Returns:
+        Dictionary containing:
+            - valid: bool - Whether validation passed
+            - record_count: int - Number of trace records (header lines)
+            - file_size: int - File size in bytes
+            - errors: List[str] - Error messages (empty if valid)
+
+    Raises:
+        FileNotFoundError: If file does not exist
+    """
+    if not filepath.exists():
+        raise FileNotFoundError(f"File not found: {filepath}")
+
+    result: Dict[str, Any] = {
+        "valid": False,
+        "record_count": 0,
+        "file_size": filepath.stat().st_size,
+        "errors": [],
+    }
+
+    # Count records (header lines)
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            for line in f:
+                if REG_INFO_HEADER_PATTERN.match(
+                    line
+                ) or MEM_ACCESS_HEADER_PATTERN.match(line):
+                    result["record_count"] += 1
+
+        if result["record_count"] == 0:
+            result["errors"].append("No trace records found in file")
+            return result
+
+    except Exception as e:
+        result["errors"].append(f"Error counting records: {str(e)}")
+        return result
+
+    # Validate format
+    try:
+        validate_text_format(filepath)
+        result["valid"] = True
+    except ValidationError as e:
+        result["errors"].append(str(e))
+    except Exception as e:
+        result["errors"].append(f"Format validation error: {str(e)}")
+
+    return result
+
+
+def parse_text_trace_record(lines: List[str]) -> Dict[str, Any]:
+    """
+    Parse a single trace record from text format.
+
+    Args:
+        lines: List of lines comprising a single trace record
+              (header line + data lines)
+
+    Returns:
+        Dictionary containing parsed fields:
+            - ctx: str - Context pointer
+            - cta: List[int] - CTA coordinates [x, y, z]
+            - warp: int - Warp ID
+            - sass: str - SASS instruction
+            - record_type: str - "reg_info" or "mem_access"
+            - data: Dict[str, Any] - Type-specific data
+
+    Raises:
+        ValueError: If record format is invalid
+    """
+    if not lines:
+        raise ValueError("Empty record")
+
+    header = lines[0]
+
+    # Try to match reg_info header
+    reg_match = re.match(
+        r"^CTX\s+(0x[0-9a-fA-F]+)\s+-\s+CTA\s+(\d+),(\d+),(\d+)\s+-\s+"
+        r"warp\s+(\d+)\s+-\s+(.+):$",
+        header,
+    )
+
+    if reg_match:
+        ctx, cta_x, cta_y, cta_z, warp, sass = reg_match.groups()
+        return {
+            "ctx": ctx,
+            "cta": [int(cta_x), int(cta_y), int(cta_z)],
+            "warp": int(warp),
+            "sass": sass,
+            "record_type": "reg_info",
+            "data": {},
+        }
+
+    # Try to match mem_access header
+    mem_match = re.match(
+        r"^CTX\s+(0x[0-9a-fA-F]+)\s+-\s+kernel_launch_id\s+(\d+)\s+-\s+"
+        r"CTA\s+(\d+),(\d+),(\d+)\s+-\s+warp\s+(\d+)\s+-\s+PC\s+(\d+)\s+-\s+(.+):$",
+        header,
+    )
+
+    if mem_match:
+        ctx, kid, cta_x, cta_y, cta_z, warp, pc, sass = mem_match.groups()
+        return {
+            "ctx": ctx,
+            "kernel_launch_id": int(kid),
+            "cta": [int(cta_x), int(cta_y), int(cta_z)],
+            "warp": int(warp),
+            "pc": int(pc),
+            "sass": sass,
+            "record_type": "mem_access",
+            "data": {},
+        }
+
+    raise ValueError(f"Unrecognized header format: {header}")


### PR DESCRIPTION

**Branch**: `findhao/python-validation-pr5-json-validator`
**Base**: `findhao/python-validation-pr4-text-validator`

## Summary

Add JSON validator for CUTracer NDJSON trace files.

## Changes

- `python/cutracer/validation/json_validator.py` (+254 lines)

## Details

### Classes
- `ValidationError`: Custom exception for validation failures

### Functions
- `validate_json_syntax()`: Line-by-line JSON syntax validation for NDJSON
- `validate_json_schema()`: Schema validation using jsonschema library
- `validate_json_trace()`: Complete validation with auto-detection

### Features
- Supports single-type and mixed-type validation modes
- Auto-detects message type from first record
- Uses Draft7Validator for JSON Schema compliance
- Configurable max_errors limit

### Dependencies
- `jsonschema` (declared in pyproject.toml)
- `.schema_loader.SCHEMAS_BY_TYPE` (from PR-3)

## Test Plan

Unit tests will be added in PR-8. Manual testing can validate against actual NDJSON trace files.

