### PR TITLE
[python] PR-6: Add Cross-Format Consistency Checker

### DIFF
--- a/python/cutracer/validation/consistency.py
+++ b/python/cutracer/validation/consistency.py
@@ -1,0 +1,386 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Cross-format consistency checker for CUTracer traces.
+
+This module provides functions to compare trace files in different formats
+(text vs NDJSON) for data consistency.
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict
+
+from .text_validator import (
+    MEM_ACCESS_HEADER_PATTERN,
+    parse_text_trace_record,
+    REG_INFO_HEADER_PATTERN,
+)
+
+
+def compare_record_counts(
+    text_metadata: Dict[str, Any], json_metadata: Dict[str, Any], tolerance: float = 0.0
+) -> bool:
+    """
+    Compare record counts between text and JSON formats.
+
+    Args:
+        text_metadata: Metadata from validate_text_trace()
+        json_metadata: Metadata from validate_json_trace()
+        tolerance: Allowed difference as fraction (default 0%)
+
+    Returns:
+        True if counts are within tolerance
+
+    Raises:
+        ValueError: If metadata is invalid or missing required fields
+    """
+    if "record_count" not in text_metadata:
+        raise ValueError("text_metadata missing 'record_count' field")
+    if "record_count" not in json_metadata:
+        raise ValueError("json_metadata missing 'record_count' field")
+
+    text_count = text_metadata["record_count"]
+    json_count = json_metadata["record_count"]
+
+    if text_count == 0 and json_count == 0:
+        return True
+
+    if text_count == 0 or json_count == 0:
+        return False
+
+    # Calculate relative difference
+    max_count = max(text_count, json_count)
+    diff = abs(text_count - json_count)
+    relative_diff = diff / max_count
+
+    return relative_diff <= tolerance
+
+
+def compare_trace_content(
+    text_file: Path, json_file: Path, sample_size: int = 10
+) -> Dict[str, Any]:
+    """
+    Compare actual trace content between formats (sampling).
+
+    Validates:
+    - Same grid_launch_id in both formats
+    - Same trace_index values
+    - Consistent SASS strings
+    - Matching CTA and warp information
+
+    Args:
+        text_file: Path to text trace file
+        json_file: Path to NDJSON trace file
+        sample_size: Number of records to sample for comparison (default: 10)
+
+    Returns:
+        Dictionary containing:
+            - consistent: bool - Whether sampled content is consistent
+            - samples_compared: int - Number of samples compared
+            - differences: List[str] - Differences found
+
+    Raises:
+        FileNotFoundError: If either file does not exist
+    """
+    if not text_file.exists():
+        raise FileNotFoundError(f"Text file not found: {text_file}")
+    if not json_file.exists():
+        raise FileNotFoundError(f"JSON file not found: {json_file}")
+
+    result: Dict[str, Any] = {
+        "consistent": True,
+        "samples_compared": 0,
+        "differences": [],
+    }
+
+    try:
+        # Read sample of JSON records
+        json_records = []
+        with open(json_file, "r", encoding="utf-8") as f:
+            for i, line in enumerate(f):
+                if i >= sample_size:
+                    break
+                line = line.strip()
+                if line:
+                    json_records.append(json.loads(line))
+
+        # Read sample of text records
+        text_records = []
+        with open(text_file, "r", encoding="utf-8") as f:
+            current_record = []
+            for line in f:
+                if not line.strip():
+                    if current_record:
+                        try:
+                            parsed = parse_text_trace_record(current_record)
+                            text_records.append(parsed)
+                            if len(text_records) >= sample_size:
+                                break
+                        except ValueError:
+                            pass
+                        current_record = []
+                    continue
+
+                if REG_INFO_HEADER_PATTERN.match(
+                    line
+                ) or MEM_ACCESS_HEADER_PATTERN.match(line):
+                    if current_record:
+                        try:
+                            parsed = parse_text_trace_record(current_record)
+                            text_records.append(parsed)
+                            if len(text_records) >= sample_size:
+                                break
+                        except ValueError:
+                            pass
+                    current_record = [line]
+                else:
+                    current_record.append(line)
+
+        # Compare the samples
+        min_samples = min(len(text_records), len(json_records))
+        result["samples_compared"] = min_samples
+
+        if min_samples == 0:
+            result["differences"].append("No records found to compare")
+            result["consistent"] = False
+            return result
+
+        for i in range(min_samples):
+            text_rec = text_records[i]
+            json_rec = json_records[i]
+
+            # Compare SASS instruction
+            text_sass = text_rec.get("sass", "").strip()
+            json_sass = json_rec.get("sass", "").strip()
+            if text_sass != json_sass:
+                result["differences"].append(
+                    f"Record {i}: SASS mismatch - text: '{text_sass}', "
+                    f"json: '{json_sass}'"
+                )
+                result["consistent"] = False
+
+            # Compare CTA coordinates
+            if "cta" in text_rec and "cta" in json_rec:
+                if text_rec["cta"] != json_rec["cta"]:
+                    result["differences"].append(
+                        f"Record {i}: CTA mismatch - text: {text_rec['cta']}, "
+                        f"json: {json_rec['cta']}"
+                    )
+                    result["consistent"] = False
+
+            # Compare warp
+            if "warp" in text_rec and "warp" in json_rec:
+                if text_rec["warp"] != json_rec["warp"]:
+                    result["differences"].append(
+                        f"Record {i}: Warp mismatch - text: {text_rec['warp']}, "
+                        f"json: {json_rec['warp']}"
+                    )
+                    result["consistent"] = False
+
+    except Exception as e:
+        result["differences"].append(f"Error during comparison: {str(e)}")
+        result["consistent"] = False
+
+    return result
+
+
+def compare_trace_formats(
+    text_file: Path, json_file: Path, tolerance: float = 0.0, sample_size: int = 10
+) -> Dict[str, Any]:
+    """
+    Comprehensive comparison of two trace formats.
+
+    Performs both record count comparison and content sampling.
+
+    Args:
+        text_file: Path to text trace file
+        json_file: Path to NDJSON trace file
+        tolerance: Allowed difference for record count (default: 0%)
+        sample_size: Number of records to sample (default: 10)
+
+    Returns:
+        Dictionary containing:
+            - consistent: bool - Overall consistency
+            - record_count_match: bool - Whether counts match
+            - content_match: bool - Whether content matches
+            - text_records: int - Number of text records
+            - json_records: int - Number of JSON records
+            - samples_compared: int - Number of samples compared
+            - differences: List[str] - All differences found
+
+    Raises:
+        FileNotFoundError: If either file does not exist
+    """
+    from .json_validator import validate_json_trace
+    from .text_validator import validate_text_trace
+
+    if not text_file.exists():
+        raise FileNotFoundError(f"Text file not found: {text_file}")
+    if not json_file.exists():
+        raise FileNotFoundError(f"JSON file not found: {json_file}")
+
+    result: Dict[str, Any] = {
+        "consistent": False,
+        "record_count_match": False,
+        "content_match": False,
+        "text_records": 0,
+        "json_records": 0,
+        "samples_compared": 0,
+        "differences": [],
+    }
+
+    try:
+        # Validate both files
+        text_metadata = validate_text_trace(text_file)
+        json_metadata = validate_json_trace(json_file)
+
+        result["text_records"] = text_metadata["record_count"]
+        result["json_records"] = json_metadata["record_count"]
+
+        # Check if validation passed
+        if not text_metadata["valid"]:
+            result["differences"].append(
+                f"Text file validation failed: {text_metadata['errors']}"
+            )
+            return result
+
+        if not json_metadata["valid"]:
+            result["differences"].append(
+                f"JSON file validation failed: {json_metadata['errors']}"
+            )
+            return result
+
+        # Compare record counts
+        count_match = compare_record_counts(
+            text_metadata, json_metadata, tolerance=tolerance
+        )
+        result["record_count_match"] = count_match
+
+        if not count_match:
+            diff = abs(result["text_records"] - result["json_records"])
+            result["differences"].append(
+                f"Record count mismatch: text={result['text_records']}, "
+                f"json={result['json_records']}, diff={diff}"
+            )
+
+        # Compare content
+        content_result = compare_trace_content(
+            text_file, json_file, sample_size=sample_size
+        )
+        result["content_match"] = content_result["consistent"]
+        result["samples_compared"] = content_result["samples_compared"]
+
+        if not content_result["consistent"]:
+            result["differences"].extend(content_result["differences"])
+
+        # Overall consistency
+        result["consistent"] = count_match and content_result["consistent"]
+
+    except Exception as e:
+        result["differences"].append(f"Comparison error: {str(e)}")
+
+    return result
+
+
+def get_trace_statistics(filepath: Path) -> Dict[str, Any]:
+    """
+    Extract statistics from a trace file.
+
+    Works with both text and JSON formats.
+
+    Args:
+        filepath: Path to trace file
+
+    Returns:
+        Dictionary containing:
+            - format: str - "text" or "json"
+            - record_count: int
+            - file_size: int
+            - message_types: Dict[str, int] - Count by message type
+            - unique_ctxs: int - Number of unique contexts
+            - unique_warps: int - Number of unique warps
+
+    Raises:
+        FileNotFoundError: If file does not exist
+        ValueError: If file format is not recognized
+    """
+    if not filepath.exists():
+        raise FileNotFoundError(f"File not found: {filepath}")
+
+    stats: Dict[str, Any] = {
+        "format": None,
+        "record_count": 0,
+        "file_size": filepath.stat().st_size,
+        "message_types": {},
+        "unique_ctxs": set(),
+        "unique_warps": set(),
+    }
+
+    # Determine format by extension
+    if filepath.suffix == ".ndjson":
+        stats["format"] = "json"
+        with open(filepath, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                    stats["record_count"] += 1
+
+                    msg_type = record.get("type", "unknown")
+                    stats["message_types"][msg_type] = (
+                        stats["message_types"].get(msg_type, 0) + 1
+                    )
+
+                    if "ctx" in record:
+                        stats["unique_ctxs"].add(record["ctx"])
+                    if "warp" in record:
+                        stats["unique_warps"].add(record["warp"])
+
+                except json.JSONDecodeError:
+                    pass
+
+    elif filepath.suffix == ".log":
+        stats["format"] = "text"
+        with open(filepath, "r", encoding="utf-8") as f:
+            for line in f:
+                if REG_INFO_HEADER_PATTERN.match(line):
+                    stats["record_count"] += 1
+                    stats["message_types"]["reg_info"] = (
+                        stats["message_types"].get("reg_info", 0) + 1
+                    )
+
+                    # Extract context
+                    ctx_match = re.search(r"CTX\s+(0x[0-9a-fA-F]+)", line)
+                    if ctx_match:
+                        stats["unique_ctxs"].add(ctx_match.group(1))
+
+                    # Extract warp
+                    warp_match = re.search(r"warp\s+(\d+)", line)
+                    if warp_match:
+                        stats["unique_warps"].add(int(warp_match.group(1)))
+
+                elif MEM_ACCESS_HEADER_PATTERN.match(line):
+                    stats["record_count"] += 1
+                    stats["message_types"]["mem_access"] = (
+                        stats["message_types"].get("mem_access", 0) + 1
+                    )
+
+                    ctx_match = re.search(r"CTX\s+(0x[0-9a-fA-F]+)", line)
+                    if ctx_match:
+                        stats["unique_ctxs"].add(ctx_match.group(1))
+
+                    warp_match = re.search(r"warp\s+(\d+)", line)
+                    if warp_match:
+                        stats["unique_warps"].add(int(warp_match.group(1)))
+    else:
+        raise ValueError(f"Unknown file format: {filepath.suffix}")
+
+    # Convert sets to counts
+    stats["unique_ctxs"] = len(stats["unique_ctxs"])
+    stats["unique_warps"] = len(stats["unique_warps"])
+
+    return stats

--- a/python/cutracer/validation/json_validator.py
+++ b/python/cutracer/validation/json_validator.py
@@ -1,0 +1,254 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+JSON validator for CUTracer NDJSON trace files.
+
+This module provides functions to validate NDJSON trace files produced by
+CUTracer for syntax correctness and schema compliance.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import jsonschema
+
+from .schema_loader import SCHEMAS_BY_TYPE
+
+
+class ValidationError(Exception):
+    """Exception raised for validation errors."""
+
+    pass
+
+
+def validate_json_syntax(filepath: Path) -> Tuple[int, List[str]]:
+    """
+    Validate JSON syntax line-by-line for NDJSON file.
+
+    Args:
+        filepath: Path to NDJSON trace file
+
+    Returns:
+        Tuple of (valid_count, errors) where:
+            - valid_count: Number of valid JSON lines parsed
+            - errors: List of error messages with line numbers
+
+    Raises:
+        FileNotFoundError: If file does not exist
+    """
+    if not filepath.exists():
+        raise FileNotFoundError(f"File not found: {filepath}")
+
+    valid_count = 0
+    errors: List[str] = []
+
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            for line_num, line in enumerate(f, start=1):
+                line = line.strip()
+                if not line:
+                    continue
+
+                try:
+                    json.loads(line)
+                    valid_count += 1
+                except json.JSONDecodeError as e:
+                    errors.append(f"Line {line_num}: JSON decode error - {e.msg}")
+
+    except Exception as e:
+        errors.append(f"File reading error: {str(e)}")
+
+    return valid_count, errors
+
+
+def validate_json_schema(
+    filepath: Path,
+    message_type: str = "reg_trace",
+    max_errors: int = 10,
+    allow_mixed_types: bool = False,
+) -> bool:
+    """
+    Validate JSON schema against TraceRecord definition.
+
+    Args:
+        filepath: Path to NDJSON trace file
+        message_type: Expected message type (default: "reg_trace")
+        max_errors: Maximum number of schema errors to collect (default: 10)
+        allow_mixed_types: If True, validate each record against its own schema
+                          based on the 'type' field. If False, all records must
+                          match the specified message_type. (default: False)
+
+    Returns:
+        True if all records pass schema validation
+
+    Raises:
+        ValidationError: If schema validation fails (includes detailed errors)
+        FileNotFoundError: If file does not exist
+        ValueError: If message_type is not recognized
+    """
+    if not filepath.exists():
+        raise FileNotFoundError(f"File not found: {filepath}")
+
+    if message_type not in SCHEMAS_BY_TYPE:
+        valid_types = ", ".join(SCHEMAS_BY_TYPE.keys())
+        raise ValueError(
+            f"Unknown message type: {message_type}. Valid types: {valid_types}"
+        )
+
+    # Pre-create validators for all types if allowing mixed types
+    validators = {
+        msg_type: jsonschema.Draft7Validator(schema)
+        for msg_type, schema in SCHEMAS_BY_TYPE.items()
+    }
+    default_validator = validators[message_type]
+
+    errors: List[str] = []
+    line_num = 0
+
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            for line_num, line in enumerate(f, start=1):
+                line = line.strip()
+                if not line:
+                    continue
+
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as e:
+                    errors.append(f"Line {line_num}: JSON syntax error - {e.msg}")
+                    if len(errors) >= max_errors:
+                        break
+                    continue
+
+                # Get the record's type
+                record_type = record.get("type", "")
+
+                if allow_mixed_types:
+                    # Validate against the appropriate schema for this record's type
+                    if record_type not in SCHEMAS_BY_TYPE:
+                        errors.append(
+                            f"Line {line_num}: Unknown message type '{record_type}'"
+                        )
+                        if len(errors) >= max_errors:
+                            break
+                        continue
+                    validator = validators[record_type]
+                else:
+                    # Check if type field matches expected type
+                    if record_type != message_type:
+                        errors.append(
+                            f"Line {line_num}: Expected type '{message_type}', "
+                            f"got '{record_type}'"
+                        )
+                        if len(errors) >= max_errors:
+                            break
+                        continue
+                    validator = default_validator
+
+                # Validate against schema
+                validation_errors = list(validator.iter_errors(record))
+                if validation_errors:
+                    for error in validation_errors[
+                        :3
+                    ]:  # Show first 3 errors per record
+                        field_path = ".".join(str(p) for p in error.path)
+                        errors.append(
+                            f"Line {line_num}: Schema error at '{field_path}': "
+                            f"{error.message}"
+                        )
+                    if len(errors) >= max_errors:
+                        break
+
+    except Exception as e:
+        errors.append(f"File reading error: {str(e)}")
+
+    if errors:
+        error_summary = "\n".join(errors)
+        if len(errors) >= max_errors:
+            error_summary += f"\n... (showing first {max_errors} errors)"
+        raise ValidationError(f"Schema validation failed:\n{error_summary}")
+
+    return True
+
+
+def validate_json_trace(filepath: Path) -> Dict[str, Any]:
+    """
+    Complete validation of NDJSON trace file.
+
+    Performs both syntax and schema validation, with auto-detection of
+    message type from the first record.
+
+    Args:
+        filepath: Path to NDJSON trace file
+
+    Returns:
+        Dictionary containing:
+            - valid: bool - Whether validation passed
+            - record_count: int - Number of valid records
+            - file_size: int - File size in bytes
+            - message_type: str - Detected message type
+            - errors: List[str] - Error messages (empty if valid)
+
+    Raises:
+        FileNotFoundError: If file does not exist
+    """
+    if not filepath.exists():
+        raise FileNotFoundError(f"File not found: {filepath}")
+
+    result: Dict[str, Any] = {
+        "valid": False,
+        "record_count": 0,
+        "file_size": filepath.stat().st_size,
+        "message_type": None,
+        "errors": [],
+    }
+
+    # Step 1: Validate syntax
+    try:
+        valid_count, syntax_errors = validate_json_syntax(filepath)
+        result["record_count"] = valid_count
+
+        if syntax_errors:
+            result["errors"].extend(syntax_errors)
+            return result
+
+        if valid_count == 0:
+            result["errors"].append("No valid JSON records found in file")
+            return result
+
+    except Exception as e:
+        result["errors"].append(f"Syntax validation error: {str(e)}")
+        return result
+
+    # Step 2: Auto-detect message type from first record
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    first_record = json.loads(line)
+                    message_type = first_record.get("type")
+                    if message_type not in SCHEMAS_BY_TYPE:
+                        result["errors"].append(
+                            f"Unknown message type in file: {message_type}"
+                        )
+                        return result
+                    result["message_type"] = message_type
+                    break
+    except Exception as e:
+        result["errors"].append(f"Failed to detect message type: {str(e)}")
+        return result
+
+    # Step 3: Validate schema (allow mixed types since trace files often contain multiple record types)
+    try:
+        validate_json_schema(
+            filepath, message_type=result["message_type"], allow_mixed_types=True
+        )
+        result["valid"] = True
+    except ValidationError as e:
+        result["errors"].append(str(e))
+    except Exception as e:
+        result["errors"].append(f"Schema validation error: {str(e)}")
+
+    return result

--- a/python/cutracer/validation/text_validator.py
+++ b/python/cutracer/validation/text_validator.py
@@ -1,0 +1,238 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Text format validator for CUTracer text trace files.
+
+This module provides functions to validate text-format trace files (mode 0)
+produced by CUTracer for format compliance.
+"""
+
+import re
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+class ValidationError(Exception):
+    """Exception raised for validation errors."""
+
+    pass
+
+
+# Regex patterns for validating text trace format
+# Pattern for header line (MSG_TYPE_REG_INFO)
+REG_INFO_HEADER_PATTERN = re.compile(
+    r"^CTX\s+0x[0-9a-fA-F]+\s+-\s+CTA\s+\d+,\d+,\d+\s+-\s+warp\s+\d+\s+-\s+.+:$"
+)
+
+# Pattern for register value line
+REGISTER_VALUE_PATTERN = re.compile(r"^\s+\*\s+(Reg\d+_T\d+:\s+0x[0-9a-fA-F]+\s*)+$")
+
+# Pattern for memory access header (MSG_TYPE_MEM_ACCESS)
+MEM_ACCESS_HEADER_PATTERN = re.compile(
+    r"^CTX\s+0x[0-9a-fA-F]+\s+-\s+kernel_launch_id\s+\d+\s+-\s+CTA\s+\d+,\d+,\d+\s+-\s+"
+    r"warp\s+\d+\s+-\s+PC\s+\d+\s+-\s+.+:$"
+)
+
+# Pattern for memory addresses
+MEMORY_ADDRESS_PATTERN = re.compile(r"T\d+:\s+0x[0-9a-fA-F]{16}")
+
+
+def validate_text_format(filepath: Path) -> bool:
+    """
+    Validate text format of trace file.
+
+    Checks for proper structure:
+    - Header lines with CTX, CTA, warp, and SASS instruction
+    - Register value lines or memory address lines
+    - Proper hex formatting
+
+    Args:
+        filepath: Path to text trace file
+
+    Returns:
+        True if format is valid
+
+    Raises:
+        ValidationError: If format validation fails
+        FileNotFoundError: If file does not exist
+    """
+    if not filepath.exists():
+        raise FileNotFoundError(f"File not found: {filepath}")
+
+    errors: List[str] = []
+    line_num = 0
+    last_was_header = False
+
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            for line_num, line in enumerate(f, start=1):
+                # Skip empty lines
+                if not line.strip():
+                    last_was_header = False
+                    continue
+
+                # Check if this is a header line
+                is_reg_header = REG_INFO_HEADER_PATTERN.match(line)
+                is_mem_header = MEM_ACCESS_HEADER_PATTERN.match(line)
+
+                if is_reg_header or is_mem_header:
+                    last_was_header = True
+                    continue
+
+                # Check if this is a register value line
+                if REGISTER_VALUE_PATTERN.match(line):
+                    if not last_was_header:
+                        errors.append(
+                            f"Line {line_num}: Register values without header"
+                        )
+                    continue
+
+                # Check if this line contains memory addresses
+                if "Memory Addresses:" in line:
+                    continue
+
+                if MEMORY_ADDRESS_PATTERN.search(line):
+                    continue
+
+                # If we get here, the line doesn't match any expected pattern
+                # Only report if it's not whitespace-only or a separator
+                if line.strip() and not line.strip().startswith("*"):
+                    errors.append(f"Line {line_num}: Unrecognized format: {line[:50]}")
+
+    except Exception as e:
+        errors.append(f"File reading error: {str(e)}")
+
+    if errors:
+        max_errors = 10
+        error_summary = "\n".join(errors[:max_errors])
+        if len(errors) > max_errors:
+            error_summary += (
+                f"\n... (showing first {max_errors} of {len(errors)} errors)"
+            )
+        raise ValidationError(f"Text format validation failed:\n{error_summary}")
+
+    return True
+
+
+def validate_text_trace(filepath: Path) -> Dict[str, Any]:
+    """
+    Complete validation of text trace file.
+
+    Performs format validation and collects file statistics.
+
+    Args:
+        filepath: Path to text trace file
+
+    Returns:
+        Dictionary containing:
+            - valid: bool - Whether validation passed
+            - record_count: int - Number of trace records (header lines)
+            - file_size: int - File size in bytes
+            - errors: List[str] - Error messages (empty if valid)
+
+    Raises:
+        FileNotFoundError: If file does not exist
+    """
+    if not filepath.exists():
+        raise FileNotFoundError(f"File not found: {filepath}")
+
+    result: Dict[str, Any] = {
+        "valid": False,
+        "record_count": 0,
+        "file_size": filepath.stat().st_size,
+        "errors": [],
+    }
+
+    # Count records (header lines)
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            for line in f:
+                if REG_INFO_HEADER_PATTERN.match(
+                    line
+                ) or MEM_ACCESS_HEADER_PATTERN.match(line):
+                    result["record_count"] += 1
+
+        if result["record_count"] == 0:
+            result["errors"].append("No trace records found in file")
+            return result
+
+    except Exception as e:
+        result["errors"].append(f"Error counting records: {str(e)}")
+        return result
+
+    # Validate format
+    try:
+        validate_text_format(filepath)
+        result["valid"] = True
+    except ValidationError as e:
+        result["errors"].append(str(e))
+    except Exception as e:
+        result["errors"].append(f"Format validation error: {str(e)}")
+
+    return result
+
+
+def parse_text_trace_record(lines: List[str]) -> Dict[str, Any]:
+    """
+    Parse a single trace record from text format.
+
+    Args:
+        lines: List of lines comprising a single trace record
+              (header line + data lines)
+
+    Returns:
+        Dictionary containing parsed fields:
+            - ctx: str - Context pointer
+            - cta: List[int] - CTA coordinates [x, y, z]
+            - warp: int - Warp ID
+            - sass: str - SASS instruction
+            - record_type: str - "reg_info" or "mem_access"
+            - data: Dict[str, Any] - Type-specific data
+
+    Raises:
+        ValueError: If record format is invalid
+    """
+    if not lines:
+        raise ValueError("Empty record")
+
+    header = lines[0]
+
+    # Try to match reg_info header
+    reg_match = re.match(
+        r"^CTX\s+(0x[0-9a-fA-F]+)\s+-\s+CTA\s+(\d+),(\d+),(\d+)\s+-\s+"
+        r"warp\s+(\d+)\s+-\s+(.+):$",
+        header,
+    )
+
+    if reg_match:
+        ctx, cta_x, cta_y, cta_z, warp, sass = reg_match.groups()
+        return {
+            "ctx": ctx,
+            "cta": [int(cta_x), int(cta_y), int(cta_z)],
+            "warp": int(warp),
+            "sass": sass,
+            "record_type": "reg_info",
+            "data": {},
+        }
+
+    # Try to match mem_access header
+    mem_match = re.match(
+        r"^CTX\s+(0x[0-9a-fA-F]+)\s+-\s+kernel_launch_id\s+(\d+)\s+-\s+"
+        r"CTA\s+(\d+),(\d+),(\d+)\s+-\s+warp\s+(\d+)\s+-\s+PC\s+(\d+)\s+-\s+(.+):$",
+        header,
+    )
+
+    if mem_match:
+        ctx, kid, cta_x, cta_y, cta_z, warp, pc, sass = mem_match.groups()
+        return {
+            "ctx": ctx,
+            "kernel_launch_id": int(kid),
+            "cta": [int(cta_x), int(cta_y), int(cta_z)],
+            "warp": int(warp),
+            "pc": int(pc),
+            "sass": sass,
+            "record_type": "mem_access",
+            "data": {},
+        }
+
+    raise ValueError(f"Unrecognized header format: {header}")


### PR DESCRIPTION

**Branch**: `findhao/python-validation-pr6-consistency`
**Base**: `findhao/python-validation-pr5-json-validator`

## Summary

Add cross-format consistency checker for comparing trace files between text and JSON formats.

## Changes

- `python/cutracer/validation/consistency.py` (+386 lines)

## Details

### Functions

- `compare_record_counts()`: Compare record counts with tolerance
- `compare_trace_content()`: Sample-based content comparison
- `compare_trace_formats()`: Comprehensive format comparison
- `get_trace_statistics()`: Extract statistics from trace files

### Features

- Supports comparison between text (.log) and JSON (.ndjson) formats
- Validates SASS instructions, CTA coordinates, and warp information
- Configurable tolerance for record count differences
- Sample-based content comparison for efficiency
- Extracts statistics: unique contexts, warps, message types

### Dependencies

- `.text_validator`: REG_INFO_HEADER_PATTERN, MEM_ACCESS_HEADER_PATTERN, parse_text_trace_record, validate_text_trace
- `.json_validator`: validate_json_trace

## Test Plan

Unit tests will be added in PR-8. Manual testing can compare actual text and JSON trace file pairs.
