### PR TITLE
[python] PR-12: Add CLI Framework with Validate Subcommand

### DIFF
--- a/python/cutracer/__main__.py
+++ b/python/cutracer/__main__.py
@@ -1,0 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Allow running cutracer as a module: python -m cutracer
+"""
+
+from cutracer.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/python/cutracer/cli.py
+++ b/python/cutracer/cli.py
@@ -1,0 +1,70 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+CUTracer CLI entry point.
+
+Provides command-line interface for trace validation and analysis.
+"""
+
+import argparse
+import sys
+from importlib.metadata import PackageNotFoundError, version
+
+from cutracer.validation.cli import _add_validate_args, validate_command
+
+
+def _get_package_version() -> str:
+    """Get package version from metadata."""
+    try:
+        return version("cutracer")
+    except PackageNotFoundError:
+        return "0+unknown"
+
+
+def main() -> int:
+    """Main CLI entry point."""
+    pkg_version = _get_package_version()
+
+    parser = argparse.ArgumentParser(
+        prog="cutraceross",
+        description="CUTracer: CUDA trace validation and analysis tools",
+        epilog=(
+            "Examples:\n"
+            "  cutraceross validate kernel_trace.ndjson\n"
+            "  cutraceross validate kernel_trace.ndjson.zst --verbose\n"
+            "  cutraceross validate trace.log --format text\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {pkg_version}",
+        help="Show program's version number and exit",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # validate subcommand
+    validate_parser = subparsers.add_parser(
+        "validate",
+        help="Validate a CUTracer trace file",
+        description=(
+            "Validate a CUTracer trace file.\n\n"
+            "Checks syntax and schema compliance for NDJSON, Zstd-compressed,\n"
+            "and text format trace files."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    _add_validate_args(validate_parser)
+    validate_parser.set_defaults(func=validate_command)
+
+    # Parse arguments
+    args = parser.parse_args()
+
+    # Execute command
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/cutracer/validation/cli.py
+++ b/python/cutracer/validation/cli.py
@@ -1,0 +1,148 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+CLI implementation for the validate subcommand.
+
+This module provides command-line interface for validating CUTracer trace files.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from .json_validator import validate_json_trace
+from .text_validator import validate_text_trace
+
+
+def _add_validate_args(parser: argparse.ArgumentParser) -> None:
+    """Add arguments for the validate subcommand."""
+    parser.add_argument(
+        "file",
+        type=Path,
+        help="Path to the trace file to validate",
+    )
+    parser.add_argument(
+        "--format",
+        "-f",
+        choices=["json", "text", "auto"],
+        default="auto",
+        help="File format. Default: auto-detect from extension.",
+    )
+    parser.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="Quiet mode. Only return exit code.",
+    )
+    parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Output results in JSON format.",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Verbose output with additional details.",
+    )
+
+
+def _detect_format(file_path: Path) -> str:
+    """Auto-detect file format from extension."""
+    suffixes = "".join(file_path.suffixes).lower()
+    if ".ndjson" in suffixes:
+        return "json"
+    elif file_path.suffix == ".log":
+        return "text"
+    else:
+        return "unknown"
+
+
+def _format_size(size_bytes: int) -> str:
+    """Format file size for display."""
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    elif size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    else:
+        return f"{size_bytes / (1024 * 1024):.1f} MB"
+
+
+def _format_trace_format(result: dict[str, Any]) -> str:
+    """Format trace format for display based on result."""
+    compression = result.get("compression", "none")
+    message_type = result.get("message_type")
+
+    if compression == "zstd":
+        return "NDJSON + Zstd"
+    elif message_type:
+        return "NDJSON"
+    else:
+        return "Text"
+
+
+def _print_validation_result(result: dict[str, Any], verbose: bool = False) -> None:
+    """Print validation result in human-readable format."""
+    if result["valid"]:
+        print("\u2705 Valid trace file")
+        print(f"   Format:       {_format_trace_format(result)}")
+        print(f"   Records:      {result['record_count']}")
+        if result.get("message_type"):
+            print(f"   Message type: {result['message_type']}")
+        if result.get("file_size"):
+            print(f"   File size:    {_format_size(result['file_size'])}")
+        if verbose and result.get("compression") == "zstd":
+            print("   Compression:  zstd")
+    else:
+        print("\u274c Validation failed")
+        for error in result.get("errors", []):
+            print(f"   {error}")
+
+
+def validate_command(args: argparse.Namespace) -> int:
+    """Execute the validate subcommand."""
+    file_path: Path = args.file
+
+    # Check file exists
+    if not file_path.exists():
+        if not args.quiet:
+            print(f"Error: File not found: {file_path}", file=sys.stderr)
+        return 2
+
+    # Detect format
+    file_format = args.format
+    if file_format == "auto":
+        file_format = _detect_format(file_path)
+        if file_format == "unknown":
+            if not args.quiet:
+                print(
+                    f"Error: Cannot auto-detect format for {file_path}. "
+                    "Use --format to specify.",
+                    file=sys.stderr,
+                )
+            return 2
+
+    # Run validation
+    if file_format == "json":
+        result = validate_json_trace(file_path)
+    else:
+        result = validate_text_trace(file_path)
+
+    # Handle quiet mode
+    if args.quiet:
+        return 0 if result["valid"] else 1
+
+    # Handle JSON output
+    if args.json_output:
+        # Convert Path objects to strings for JSON serialization
+        output = {k: str(v) if isinstance(v, Path) else v for k, v in result.items()}
+        print(json.dumps(output, indent=2))
+        return 0 if result["valid"] else 1
+
+    # Human-readable output
+    _print_validation_result(result, args.verbose)
+
+    return 0 if result["valid"] else 1

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -34,9 +34,8 @@ dev = [
 "Homepage" = "https://github.com/facebookresearch/CUTracer"
 "Bug Tracker" = "https://github.com/facebookresearch/CUTracer/issues"
 
-# Note: CLI entry points can be added when cutracer.cli module is implemented
-# [project.scripts]
-# validate-trace = "cutracer.cli:main"
+[project.scripts]
+cutraceross = "cutracer.cli:main"
 
 [tool.black]
 line-length = 88

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1,0 +1,223 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Tests for cutracer CLI."""
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from cutracer.cli import main
+from cutracer.validation.cli import _detect_format, _format_size
+
+
+class DetectFormatTest(unittest.TestCase):
+    """Tests for _detect_format function."""
+
+    def test_detect_ndjson(self):
+        self.assertEqual(_detect_format(Path("trace.ndjson")), "json")
+
+    def test_detect_ndjson_zst(self):
+        self.assertEqual(_detect_format(Path("trace.ndjson.zst")), "json")
+
+    def test_detect_log(self):
+        self.assertEqual(_detect_format(Path("trace.log")), "text")
+
+    def test_detect_unknown(self):
+        self.assertEqual(_detect_format(Path("trace.txt")), "unknown")
+        self.assertEqual(_detect_format(Path("trace.bin")), "unknown")
+
+
+class FormatSizeTest(unittest.TestCase):
+    """Tests for _format_size function."""
+
+    def test_format_bytes(self):
+        self.assertEqual(_format_size(500), "500 B")
+
+    def test_format_kilobytes(self):
+        self.assertEqual(_format_size(2048), "2.0 KB")
+
+    def test_format_megabytes(self):
+        self.assertEqual(_format_size(1048576), "1.0 MB")
+        self.assertEqual(_format_size(2621440), "2.5 MB")
+
+
+class ValidateCommandTest(unittest.TestCase):
+    """Tests for validate subcommand."""
+
+    def setUp(self):
+        self.test_dir = Path(__file__).parent / "example_inputs"
+
+    def test_validate_valid_json(self):
+        """Test validating a valid NDJSON file."""
+        with patch(
+            "sys.argv",
+            ["cutraceross", "validate", str(self.test_dir / "reg_trace_sample.ndjson")],
+        ):
+            exit_code = main()
+            self.assertEqual(exit_code, 0)
+
+    def test_validate_valid_json_zst(self):
+        """Test validating a valid Zstd-compressed NDJSON file."""
+        with patch(
+            "sys.argv",
+            [
+                "cutraceross",
+                "validate",
+                str(self.test_dir / "reg_trace_sample.ndjson.zst"),
+            ],
+        ):
+            exit_code = main()
+            self.assertEqual(exit_code, 0)
+
+    def test_validate_valid_text(self):
+        """Test validating a valid text log file."""
+        with patch(
+            "sys.argv",
+            ["cutraceross", "validate", str(self.test_dir / "reg_trace_sample.log")],
+        ):
+            exit_code = main()
+            self.assertEqual(exit_code, 0)
+
+    def test_validate_invalid_syntax(self):
+        """Test validating a file with invalid JSON syntax."""
+        with patch(
+            "sys.argv",
+            ["cutraceross", "validate", str(self.test_dir / "invalid_syntax.ndjson")],
+        ):
+            exit_code = main()
+            self.assertEqual(exit_code, 1)
+
+    def test_validate_invalid_schema(self):
+        """Test validating a file with schema errors."""
+        with patch(
+            "sys.argv",
+            ["cutraceross", "validate", str(self.test_dir / "invalid_schema.ndjson")],
+        ):
+            exit_code = main()
+            self.assertEqual(exit_code, 1)
+
+    def test_validate_quiet_mode(self):
+        """Test quiet mode returns only exit code."""
+        with patch(
+            "sys.argv",
+            [
+                "cutraceross",
+                "validate",
+                "--quiet",
+                str(self.test_dir / "reg_trace_sample.ndjson"),
+            ],
+        ):
+            exit_code = main()
+            self.assertEqual(exit_code, 0)
+
+    def test_validate_json_output(self):
+        """Test JSON output format."""
+        with patch(
+            "sys.argv",
+            [
+                "cutraceross",
+                "validate",
+                "--json",
+                str(self.test_dir / "reg_trace_sample.ndjson"),
+            ],
+        ):
+            exit_code = main()
+            self.assertEqual(exit_code, 0)
+
+    def test_validate_file_not_found(self):
+        """Test error handling for non-existent file."""
+        with patch("sys.argv", ["cutraceross", "validate", "/nonexistent/file.ndjson"]):
+            exit_code = main()
+            self.assertEqual(exit_code, 2)
+
+    def test_validate_unknown_format(self):
+        """Test error handling for unknown format."""
+        with patch(
+            "sys.argv",
+            [
+                "cutraceross",
+                "validate",
+                str(self.test_dir / "reg_trace_sample.ndjson").replace(
+                    ".ndjson", ".unknown"
+                ),
+            ],
+        ):
+            exit_code = main()
+            self.assertEqual(exit_code, 2)
+
+    def test_validate_explicit_format_json(self):
+        """Test explicit --format json option."""
+        with patch(
+            "sys.argv",
+            [
+                "cutraceross",
+                "validate",
+                "--format",
+                "json",
+                str(self.test_dir / "reg_trace_sample.ndjson"),
+            ],
+        ):
+            exit_code = main()
+            self.assertEqual(exit_code, 0)
+
+    def test_validate_explicit_format_text(self):
+        """Test explicit --format text option."""
+        with patch(
+            "sys.argv",
+            [
+                "cutraceross",
+                "validate",
+                "--format",
+                "text",
+                str(self.test_dir / "reg_trace_sample.log"),
+            ],
+        ):
+            exit_code = main()
+            self.assertEqual(exit_code, 0)
+
+
+class MainEntryPointTest(unittest.TestCase):
+    """Tests for main entry point."""
+
+    def test_version_flag(self):
+        """Test --version flag."""
+        with patch("sys.argv", ["cutraceross", "--version"]):
+            with self.assertRaises(SystemExit) as cm:
+                main()
+            self.assertEqual(cm.exception.code, 0)
+
+    def test_help_flag(self):
+        """Test --help flag."""
+        with patch("sys.argv", ["cutraceross", "--help"]):
+            with self.assertRaises(SystemExit) as cm:
+                main()
+            self.assertEqual(cm.exception.code, 0)
+
+    def test_no_command(self):
+        """Test error when no command is provided."""
+        with patch("sys.argv", ["cutraceross"]):
+            with self.assertRaises(SystemExit) as cm:
+                main()
+            self.assertNotEqual(cm.exception.code, 0)
+
+
+class ModuleEntryPointTest(unittest.TestCase):
+    """Tests for python -m cutracer entry point."""
+
+    def test_module_help(self):
+        """Test python -m cutracer --help works."""
+        result = subprocess.run(
+            [sys.executable, "-m", "cutracer", "--help"],
+            capture_output=True,
+            text=True,
+            cwd=Path(__file__).parent.parent,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("cutraceross", result.stdout)
+        self.assertIn("validate", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

## Summary

Add a command-line interface (CLI) for cutracer using argparse. Following the tritonparse pattern, the validate command logic is placed in `validation/cli.py` for better modularity and extensibility.

## Changes

| File | Lines | Description |
|------|-------|-------------|
| `python/pyproject.toml` | +2/-3 | Add CLI entry point `cutraceross` |
| `python/cutracer/cli.py` | +70 | Main CLI entry point with subcommand registration |
| `python/cutracer/validation/cli.py` | +148 | Validate subcommand implementation |
| `python/cutracer/__main__.py` | +10 | Support for `python -m cutracer` |
| `python/tests/test_cli.py` | +223 | Comprehensive CLI tests (22 test cases) |
| **Total** | **~453** | |

## Features

### CLI Entry Point
```bash
pip install -e .
cutraceross --help
cutraceross --version
```

### Validate Subcommand
```bash
# Basic usage
cutraceross validate kernel_trace.ndjson
cutraceross validate kernel_trace.ndjson.zst
cutraceross validate trace.log

# Options
cutraceross validate <file> --format json|text|auto
cutraceross validate <file> --quiet      # Only return exit code
cutraceross validate <file> --json       # JSON output format
cutraceross validate <file> --verbose    # Detailed output
```

### Exit Codes
- `0`: Validation passed
- `1`: Validation failed
- `2`: File not found or format detection error

## Architecture

Following tritonparse's modular pattern:

```
cutracer/
├── cli.py                     # Main entry, subcommand registration (70 lines)
├── __main__.py                # python -m cutracer support (10 lines)
└── validation/
    ├── cli.py                 # validate subcommand logic (148 lines)
    ├── json_validator.py
    ├── text_validator.py
    └── ...
```

This structure allows easy addition of future subcommands (parse, stats, compare) by adding `cli.py` to their respective modules.

## Testing

- 22 test cases covering all CLI functionality
- All tests pass ✅

## Dependencies

- Uses Python standard library `argparse` (no new dependencies)
- Consistent with tritonparse_oss implementation style
