### PR TITLE
[python] PR-13: Add Nightly PyPI Publish Workflow

### DIFF
--- a/.github/workflows/nightly-pypi.yml
+++ b/.github/workflows/nightly-pypi.yml
@@ -1,0 +1,82 @@
+name: Nightly PyPI Publish
+on:
+  schedule:
+    - cron: "18 7 * * *"   # 07:18 UTC daily
+  workflow_dispatch: {}     # allow manual runs (no publish)
+  push:
+    tags:
+      - "v*"
+      - "*.*.*"
+
+permissions:
+  contents: read
+  id-token: write  # Required for Trusted Publishing (OIDC)
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0      # setuptools-scm requires full history/tags
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check for new commits since last nightly
+        id: check
+        if: github.ref_type != 'tag'
+        env:
+          PACKAGE_NAME: cutracer
+          PACKAGE_PATH: python/
+        run: |
+          curl -fsSL https://github.com/meta-pytorch/tritonparse/raw/refs/heads/main/.github/scripts/check_new_commits.sh | bash
+
+      - name: Compute nightly version from latest tag (next patch + timestamp)
+        id: ver
+        if: github.ref_type != 'tag' && steps.check.outputs.should_publish != 'false'
+        run: |
+          # Get latest tag; allow 'v' prefix; fail if none
+          if ! TAG=$(git describe --tags --abbrev=0 2>/dev/null); then
+            echo "::error title=No git tag found::Repository has no tags. Add a semver tag like v0.1.0"
+            exit 1
+          fi
+          BASE=${TAG#v}
+          # Keep only X.Y.Z form (strip rc/a/b/post/dev suffixes)
+          BASE=$(printf "%s\n" "$BASE" | sed -E 's/^([0-9]+)\.([0-9]+)\.([0-9]+).*/\1.\2.\3/')
+          IFS='.' read -r MAJ MIN PAT <<EOF
+          $BASE
+          EOF
+          # Use next patch version as the nightly base
+          PAT=$((PAT + 1))
+          NEXT="$MAJ.$MIN.$PAT"
+          DATE=$(date -u +%Y%m%d%H%M%S)
+          echo "NVER=${NEXT}.dev${DATE}" >> "$GITHUB_OUTPUT"
+          echo "Computed nightly version: ${NEXT}.dev${DATE}"
+
+      - name: Build sdist/wheel
+        if: github.ref_type == 'tag' || steps.check.outputs.should_publish != 'false'
+        run: |
+          python -m pip install --upgrade pip
+          pip install build setuptools-scm
+          if [ "${{ github.ref_type }}" != "tag" ]; then
+            export SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.ver.outputs.NVER }}
+          fi
+          cd python
+          python -m build
+
+      - name: Check metadata
+        if: github.ref_type == 'tag' || steps.check.outputs.should_publish != 'false'
+        run: |
+          pip install twine
+          twine check python/dist/*
+
+      - name: Publish to PyPI (Trusted Publishing)
+        if: (github.event_name == 'schedule' || github.ref_type == 'tag') && steps.check.outputs.should_publish != 'false'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: python/dist/
+          attestations: true
+          skip-existing: true

--- a/.github/workflows/nightly-pypi.yml
+++ b/.github/workflows/nightly-pypi.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           python-version: "3.12"
 
+      # This step checks if there are new commits since the last nightly publish.
+      # Output: steps.check.outputs.should_publish - 'true' if new commits exist, 'false' otherwise
       - name: Check for new commits since last nightly
         id: check
         if: github.ref_type != 'tag'
@@ -44,11 +46,14 @@ jobs:
             exit 1
           fi
           BASE=${TAG#v}
+          # Require a semantic version X.Y.Z (optionally with a suffix) before proceeding
+          if ! printf "%s\n" "$BASE" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error title=Invalid git tag::Latest tag '$TAG' is not a semantic version like v0.1.0"
+            exit 1
+          fi
           # Keep only X.Y.Z form (strip rc/a/b/post/dev suffixes)
           BASE=$(printf "%s\n" "$BASE" | sed -E 's/^([0-9]+)\.([0-9]+)\.([0-9]+).*/\1.\2.\3/')
-          IFS='.' read -r MAJ MIN PAT <<EOF
-          $BASE
-          EOF
+          IFS='.' read -r MAJ MIN PAT <<< "$BASE"
           # Use next patch version as the nightly base
           PAT=$((PAT + 1))
           NEXT="$MAJ.$MIN.$PAT"


### PR DESCRIPTION

## Summary

Add GitHub Actions workflow for automated nightly PyPI publishing of the cutracer Python package.

## Changes

### New Files
- `.github/workflows/nightly-pypi.yml` (82 lines)

## Features

1. **Scheduled Nightly Builds**: Daily at 07:18 UTC
2. **Tag-based Releases**: Publish on `v*` or `*.*.*` tags
3. **Trusted Publishing**: Uses OIDC for secure PyPI uploads (no API tokens)
4. **Smart Commit Detection**: Only publishes when there are new commits in `python/` directory
5. **Script Reuse**: Downloads `check_new_commits.sh` from tritonparse repo instead of maintaining local copy

## Key Design Decisions

### Using tritonparse's check_new_commits.sh
Instead of maintaining a local copy of the commit check script, this workflow downloads it directly from tritonparse:
```yaml
env:
  PACKAGE_NAME: cutracer
  PACKAGE_PATH: python/
run: |
  curl -fsSL https://github.com/meta-pytorch/tritonparse/raw/refs/heads/main/.github/scripts/check_new_commits.sh | bash
```

**Benefits:**
- No duplicate code to maintain
- Automatic updates when tritonparse improves the script
- Consistent behavior across projects

### Subdirectory Support
CUTracer's Python package is in `python/` subdirectory, so:
- Build commands use `cd python` before `python -m build`
- `packages-dir: python/dist/` for PyPI publish action
- `PACKAGE_PATH: python/` to filter commits

## Test Plan

1. Workflow syntax validated by GitHub Actions
2. Manual trigger via `workflow_dispatch` for testing (won't publish)
3. Full publish flow tested via git tag push

## Dependencies

- Requires tritonparse PR (PACKAGE_PATH support) to be merged first
- PyPI Trusted Publishing must be configured for cutracer package
