### PR TITLE
Align Python formatting with internal pyfmt and tritonparse

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install Python formatting tools
         run: |
-          pip install usort ruff black
+          pip install -e "./python[dev]"
 
       - name: Run formatter check
         run: |

--- a/format.sh
+++ b/format.sh
@@ -49,15 +49,15 @@ format_and_report_changes() {
 # Export the function so it's available to the subshells created by xargs.
 export -f format_and_report_changes
 
-# Python checks/format aligned with format_fix.py: usort -> ruff -> black
+# Python checks/format: ufmt (sorter + formatter from pyproject.toml) -> ruff linting
 python_check() {
   local failed=0
 
-  if command -v usort &>/dev/null; then
-    usort check .
+  if command -v ufmt &>/dev/null; then
+    ufmt check .
     [ $? -eq 0 ] || failed=1
   else
-    echo "❌ usort not found (required for Python import sorting)." >&2
+    echo "❌ ufmt not found (required for Python formatting)." >&2
     failed=1
   fi
 
@@ -69,23 +69,15 @@ python_check() {
     failed=1
   fi
 
-  if command -v black &>/dev/null; then
-    black --check --diff .
-    [ $? -eq 0 ] || failed=1
-  else
-    echo "❌ black not found (required for Python formatting)." >&2
-    failed=1
-  fi
-
   return $failed
 }
 
 python_format() {
-  if command -v usort &>/dev/null; then
-    echo "🎨  Sorting Python imports with usort..."
-    usort format .
+  if command -v ufmt &>/dev/null; then
+    echo "🎨  Formatting Python code with ufmt..."
+    ufmt format .
   else
-    echo "⚠️  usort not found; skipping import sorting." >&2
+    echo "⚠️  ufmt not found; skipping formatting." >&2
   fi
 
   if command -v ruff &>/dev/null; then
@@ -93,13 +85,6 @@ python_format() {
     ruff check . --fix
   else
     echo "⚠️  ruff not found; skipping lint fixes." >&2
-  fi
-
-  if command -v black &>/dev/null; then
-    echo "🎨  Formatting Python code with black..."
-    black .
-  else
-    echo "⚠️  black not found; skipping code formatting." >&2
   fi
 }
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -25,10 +25,10 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "mypy>=1.0.0",
-    "black>=22.0.0",
-    "ruff>=0.1.0",
-    "ufmt>=2.0.0",
-    "usort>=1.0.0",
+    "ufmt==2.9.0",
+    "usort==1.1.0",
+    "ruff-api==0.2.0",
+    "ruff>=0.4.0",
 ]
 
 [project.urls]
@@ -38,20 +38,6 @@ dev = [
 [project.scripts]
 cutraceross = "cutracer.cli:main"
 
-[tool.black]
-line-length = 88
-target-version = ["py310"]
-exclude = '''
-/(
-    \.git
-  | \.mypy_cache
-  | \.pytest_cache
-  | \.venv
-  | build
-  | dist
-)/
-'''
-
 [tool.setuptools.packages.find]
 include = ["cutracer*"]
 
@@ -59,8 +45,12 @@ include = ["cutracer*"]
 "cutracer.validation.schemas" = ["*.json"]
 
 [tool.ufmt]
-formatter = "black"
+formatter = "ruff-api"
 sorter = "usort"
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"
 
 [tool.usort]
 first_party_detection = false


### PR DESCRIPTION
Summary:
This change aligns CUTracer's Python formatting configuration with the internal pyfmt config used by `arc f` and tritonparse.

**Problem:**
CUTracer was using a separate toolchain (usort → ruff → black) for Python formatting, which could produce different results compared to internal `arc f` and tritonparse's `make format`.

**Solution:**
1. Update `python/pyproject.toml`:
   - Change `[tool.ufmt] formatter` from `"black"` to `"ruff-api"`
   - Remove `[tool.black]` section (replaced by `[tool.ruff]`)
   - Add `[tool.ruff]` section with `line-length = 88` and `target-version = "py310"`
   - Pin dev dependencies to match internal pyfmt versions:
     - ufmt==2.9.0
     - usort==1.1.0
     - ruff-api==0.2.0
     - ruff>=0.4.0

2. Update `format.sh`:
   - Replace separate `usort` + `black` calls with unified `ufmt` command
   - `ufmt` reads configuration from `pyproject.toml` and handles both import sorting (usort) and code formatting (ruff-api)
   - Keep `ruff check` for linting

Now CUTracer's `./format.sh format` produces the same results as `arc f` and tritonparse's `make format`.

Differential Revision: D90553008


