### PR TITLE
add TraceReader for NDJSON files

### DIFF
--- a/python/cutracer/analysis/__init__.py
+++ b/python/cutracer/analysis/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+CUTracer analysis module.
+
+Provides analysis utilities for trace files:
+- TraceReader: Read and iterate over trace records
+"""
+
+from .reader import TraceReader
+
+__all__ = ["TraceReader"]

--- a/python/cutracer/analysis/reader.py
+++ b/python/cutracer/analysis/reader.py
@@ -1,0 +1,67 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Trace reader for CUTracer analysis.
+
+This module provides the TraceReader class for reading and iterating
+over trace records from NDJSON files (plain or Zstd-compressed).
+"""
+
+import json
+from pathlib import Path
+from typing import Iterator, Union
+
+from cutracer.validation.compression import detect_compression, open_trace_file
+
+
+class TraceReader:
+    """
+    Reader for CUTracer trace files.
+
+    Supports NDJSON format with optional Zstd compression.
+    Provides efficient iteration over trace records.
+
+    Example:
+        >>> reader = TraceReader("trace.ndjson.zst")
+        >>> for record in reader.iter_records():
+        ...     print(record["sass"])
+    """
+
+    def __init__(self, file_path: Union[str, Path]) -> None:
+        """
+        Initialize the TraceReader.
+
+        Args:
+            file_path: Path to the trace file (.ndjson or .ndjson.zst)
+
+        Raises:
+            FileNotFoundError: If the file does not exist
+        """
+        self.file_path = Path(file_path)
+
+        if not self.file_path.exists():
+            raise FileNotFoundError(f"File not found: {self.file_path}")
+
+        self.compression = detect_compression(self.file_path)
+
+    def iter_records(self) -> Iterator[dict]:
+        """
+        Iterate over all trace records in the file.
+
+        Yields:
+            dict: Each trace record as a dictionary
+
+        Raises:
+            json.JSONDecodeError: If a line contains invalid JSON
+
+        Example:
+            >>> reader = TraceReader("trace.ndjson")
+            >>> for record in reader.iter_records():
+            ...     process(record)
+        """
+        with open_trace_file(self.file_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                yield json.loads(line)

--- a/python/tests/test_reader.py
+++ b/python/tests/test_reader.py
@@ -1,0 +1,160 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Unit tests for TraceReader class.
+"""
+
+import json
+import types
+import unittest
+
+from cutracer.analysis import TraceReader
+from tests.test_base import (
+    BaseValidationTest,
+    REG_TRACE_NDJSON,
+    REG_TRACE_NDJSON_RECORD_COUNT,
+    REG_TRACE_NDJSON_ZST,
+    REG_TRACE_NDJSON_ZST_RECORD_COUNT,
+)
+
+
+class TestTraceReaderInit(BaseValidationTest):
+    """Tests for TraceReader initialization."""
+
+    def test_init_with_ndjson_file(self):
+        """Test initialization with a plain NDJSON file."""
+        reader = TraceReader(REG_TRACE_NDJSON)
+        self.assertEqual(reader.file_path, REG_TRACE_NDJSON)
+        self.assertEqual(reader.compression, "none")
+
+    def test_init_with_zst_file(self):
+        """Test initialization with a Zstd-compressed NDJSON file."""
+        reader = TraceReader(REG_TRACE_NDJSON_ZST)
+        self.assertEqual(reader.file_path, REG_TRACE_NDJSON_ZST)
+        self.assertEqual(reader.compression, "zstd")
+
+    def test_init_with_string_path(self):
+        """Test initialization with a string path."""
+        reader = TraceReader(str(REG_TRACE_NDJSON))
+        self.assertEqual(reader.file_path, REG_TRACE_NDJSON)
+
+    def test_init_with_nonexistent_file(self):
+        """Test that FileNotFoundError is raised for non-existent file."""
+        with self.assertRaises(FileNotFoundError):
+            TraceReader("/nonexistent/path/file.ndjson")
+
+
+class TestTraceReaderIterRecords(BaseValidationTest):
+    """Tests for TraceReader.iter_records() method."""
+
+    def test_iter_records_ndjson(self):
+        """Test iterating over records in a plain NDJSON file."""
+        reader = TraceReader(REG_TRACE_NDJSON)
+        records = list(reader.iter_records())
+
+        self.assertEqual(len(records), REG_TRACE_NDJSON_RECORD_COUNT)
+
+        # Verify first record structure
+        first_record = records[0]
+        self.assertIn("type", first_record)
+        self.assertIn("warp", first_record)
+        self.assertIn("sass", first_record)
+        self.assertEqual(first_record["type"], "reg_trace")
+
+    def test_iter_records_zst(self):
+        """Test iterating over records in a Zstd-compressed NDJSON file."""
+        reader = TraceReader(REG_TRACE_NDJSON_ZST)
+        records = list(reader.iter_records())
+
+        self.assertEqual(len(records), REG_TRACE_NDJSON_ZST_RECORD_COUNT)
+
+    def test_iter_records_zst_has_valid_structure(self):
+        """Test that Zstd compressed file records have valid structure."""
+        reader = TraceReader(REG_TRACE_NDJSON_ZST)
+        records = list(reader.iter_records())
+
+        self.assertGreater(len(records), 0)
+
+        # Verify record structure
+        first_record = records[0]
+        self.assertIn("type", first_record)
+        self.assertIn("warp", first_record)
+        self.assertIn("sass", first_record)
+
+    def test_iter_records_is_generator(self):
+        """Test that iter_records returns a generator (lazy evaluation)."""
+        reader = TraceReader(REG_TRACE_NDJSON)
+        result = reader.iter_records()
+
+        # Should be a generator, not a list
+        self.assertIsInstance(result, types.GeneratorType)
+
+    def test_iter_records_can_iterate_multiple_times(self):
+        """Test that iter_records can be called multiple times."""
+        reader = TraceReader(REG_TRACE_NDJSON)
+
+        # First iteration
+        records1 = list(reader.iter_records())
+        # Second iteration
+        records2 = list(reader.iter_records())
+
+        self.assertEqual(len(records1), len(records2))
+        self.assertEqual(records1[0], records2[0])
+
+
+class TestTraceReaderEdgeCases(BaseValidationTest):
+    """Edge case tests for TraceReader."""
+
+    def test_empty_file(self):
+        """Test reading an empty file."""
+        filepath = self.create_temp_file("empty.ndjson", "")
+
+        reader = TraceReader(filepath)
+        records = list(reader.iter_records())
+
+        self.assertEqual(len(records), 0)
+
+    def test_single_record_file(self):
+        """Test reading a file with a single record."""
+        content = '{"type": "reg_trace", "warp": 0, "sass": "NOP ;"}\n'
+        filepath = self.create_temp_file("single.ndjson", content)
+
+        reader = TraceReader(filepath)
+        records = list(reader.iter_records())
+
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["type"], "reg_trace")
+
+    def test_empty_lines_skipped(self):
+        """Test that empty lines in the file are skipped."""
+        content = (
+            '{"type": "reg_trace", "warp": 0}\n\n{"type": "reg_trace", "warp": 1}\n'
+        )
+        filepath = self.create_temp_file("test.ndjson", content)
+
+        reader = TraceReader(filepath)
+        records = list(reader.iter_records())
+
+        self.assertEqual(len(records), 2)
+        self.assertEqual(records[0]["warp"], 0)
+        self.assertEqual(records[1]["warp"], 1)
+
+    def test_invalid_json_raises_error(self):
+        """Test that invalid JSON raises JSONDecodeError."""
+        content = '{"type": "reg_trace"}\n{invalid json}\n'
+        filepath = self.create_temp_file("invalid.ndjson", content)
+
+        reader = TraceReader(filepath)
+        iterator = reader.iter_records()
+
+        # First record should work
+        first = next(iterator)
+        self.assertEqual(first["type"], "reg_trace")
+
+        # Second record should raise
+        with self.assertRaises(json.JSONDecodeError):
+            next(iterator)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
Add TraceReader class for reading and iterating over trace records from
NDJSON files with optional Zstd compression support.

This is the first PR in a series that adds trace analysis functionality
to CUTracer. The TraceReader provides:
- Lazy iteration over trace records (memory-efficient)
- Automatic detection and handling of Zstd compression
- Support for both plain .ndjson and compressed .ndjson.zst files

Differential Revision: D90600726


