### PR TITLE
add analyze CLI with head/tail/filter

### DIFF
--- a/python/cutracer/analysis/__init__.py
+++ b/python/cutracer/analysis/__init__.py
@@ -5,8 +5,10 @@ CUTracer analysis module.
 
 Provides analysis utilities for trace files:
 - TraceReader: Read and iterate over trace records
+- parse_filter_expr: Parse filter expressions for record filtering
+- select_records: Memory-efficient record selection
 """
 
-from .reader import TraceReader
+from .reader import parse_filter_expr, select_records, TraceReader
 
-__all__ = ["TraceReader"]
+__all__ = ["TraceReader", "parse_filter_expr", "select_records"]

--- a/python/cutracer/analysis/__init__.py
+++ b/python/cutracer/analysis/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+CUTracer analysis module.
+
+Provides analysis utilities for trace files:
+- TraceReader: Read and iterate over trace records
+"""
+
+from .reader import TraceReader
+
+__all__ = ["TraceReader"]

--- a/python/cutracer/analysis/__init__.py
+++ b/python/cutracer/analysis/__init__.py
@@ -7,8 +7,28 @@ Provides analysis utilities for trace files:
 - TraceReader: Read and iterate over trace records
 - parse_filter_expr: Parse filter expressions for record filtering
 - select_records: Memory-efficient record selection
+- Formatters: Output formatting for table/json/csv
 """
 
+from .formatters import (
+    DEFAULT_FIELDS,
+    format_records_csv,
+    format_records_json,
+    format_records_table,
+    format_value,
+    get_display_fields,
+)
 from .reader import parse_filter_expr, select_records, TraceReader
 
-__all__ = ["TraceReader", "parse_filter_expr", "select_records"]
+__all__ = [
+    "TraceReader",
+    "parse_filter_expr",
+    "select_records",
+    # Formatters
+    "DEFAULT_FIELDS",
+    "format_value",
+    "get_display_fields",
+    "format_records_table",
+    "format_records_json",
+    "format_records_csv",
+]

--- a/python/cutracer/analysis/cli.py
+++ b/python/cutracer/analysis/cli.py
@@ -1,0 +1,86 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+CLI implementation for the analyze subcommand.
+
+Provides command-line interface for analyzing CUTracer trace files.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+import click
+from cutracer.analysis.formatters import format_records_table, get_display_fields
+from cutracer.analysis.reader import parse_filter_expr, select_records, TraceReader
+
+
+@click.command(name="analyze")
+@click.argument("file", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--head",
+    "-n",
+    type=int,
+    default=10,
+    show_default=True,
+    help="Number of records to show from the beginning.",
+)
+@click.option(
+    "--tail",
+    "-t",
+    type=int,
+    default=None,
+    help="Number of records to show from the end (overrides --head).",
+)
+@click.option(
+    "--filter",
+    "-f",
+    "filter_expr",
+    type=str,
+    default=None,
+    help="Filter expression (e.g., 'warp=24').",
+)
+def analyze_command(
+    file: Path,
+    head: int,
+    tail: Optional[int],
+    filter_expr: Optional[str],
+) -> None:
+    """
+    Analyze trace data from FILE.
+
+    Reads NDJSON trace files (plain or Zstd-compressed) and displays
+    records in a formatted table.
+
+    \b
+    Examples:
+      cutracer analyze trace.ndjson
+      cutracer analyze trace.ndjson.zst --head 20
+      cutracer analyze trace.ndjson --tail 5
+      cutracer analyze trace.ndjson --filter "warp=24"
+    """
+    # Create reader
+    try:
+        reader = TraceReader(file)
+    except FileNotFoundError as e:
+        raise click.ClickException(str(e))
+
+    # Get records iterator
+    records = reader.iter_records()
+
+    # Apply filter if specified
+    if filter_expr:
+        try:
+            predicate = parse_filter_expr(filter_expr)
+        except ValueError as e:
+            raise click.ClickException(str(e))
+        records = (r for r in records if predicate(r))
+
+    # Apply head/tail selection
+    selected = select_records(records, head=head, tail=tail)
+
+    # Determine fields to display
+    fields = get_display_fields(selected)
+
+    # Format and output
+    output = format_records_table(selected, fields)
+    click.echo(output)

--- a/python/cutracer/analysis/formatters.py
+++ b/python/cutracer/analysis/formatters.py
@@ -1,0 +1,170 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Record formatting utilities for different output formats.
+
+Provides functions to format trace records as table, JSON, or CSV.
+All functions are pure (no side effects) and return strings.
+"""
+
+import csv
+import io
+import json
+from typing import Optional
+
+# Default fields to display when --fields is not specified
+DEFAULT_FIELDS = ["warp", "pc", "sass"]
+
+
+def format_value(value) -> str:
+    """
+    Format a value for display.
+
+    Handles special cases:
+    - None -> empty string
+    - bool -> lowercase "true"/"false"
+    - list -> comma-separated values in brackets
+    - dict -> JSON string
+    - other -> str()
+
+    Args:
+        value: Any value to format
+
+    Returns:
+        String representation suitable for display
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, list):
+        return "[" + ",".join(str(v) for v in value) + "]"
+    if isinstance(value, dict):
+        return json.dumps(value)
+    return str(value)
+
+
+def get_display_fields(
+    records: list[dict], requested_fields: Optional[str] = None
+) -> list[str]:
+    """
+    Determine which fields to display.
+
+    Args:
+        records: List of trace records
+        requested_fields: Comma-separated field names or None
+
+    Returns:
+        List of field names to display
+    """
+    if requested_fields:
+        return [f.strip() for f in requested_fields.split(",")]
+
+    # Use default fields, but only if they exist in the records
+    if records:
+        available_fields = set(records[0].keys())
+        return [f for f in DEFAULT_FIELDS if f in available_fields]
+
+    return DEFAULT_FIELDS
+
+
+def format_records_table(
+    records: list[dict],
+    fields: list[str],
+    show_header: bool = True,
+) -> str:
+    """
+    Format records as a plain text table with aligned columns.
+
+    Args:
+        records: List of trace records
+        fields: List of field names to display
+        show_header: Whether to show the table header
+
+    Returns:
+        Formatted table string
+    """
+    if not records:
+        return "No records found."
+
+    # Calculate column widths
+    col_widths = {}
+    for field in fields:
+        # Start with header width if showing header
+        max_width = len(field) if show_header else 0
+        for record in records:
+            val_str = format_value(record.get(field, ""))
+            max_width = max(max_width, len(val_str))
+        col_widths[field] = max_width
+
+    lines = []
+
+    # Header row
+    if show_header:
+        header_parts = [field.upper().ljust(col_widths[field]) for field in fields]
+        lines.append("  ".join(header_parts))
+
+    # Data rows
+    for record in records:
+        row_parts = []
+        for field in fields:
+            val_str = format_value(record.get(field, ""))
+            row_parts.append(val_str.ljust(col_widths[field]))
+        lines.append("  ".join(row_parts))
+
+    return "\n".join(lines)
+
+
+def format_records_json(records: list[dict], fields: list[str]) -> str:
+    """
+    Format records as JSON.
+
+    Args:
+        records: List of trace records
+        fields: List of field names to include
+
+    Returns:
+        JSON formatted string (pretty-printed array)
+    """
+    if not records:
+        return "[]"
+
+    # Filter to only requested fields
+    filtered_records = []
+    for record in records:
+        filtered_record = {f: record.get(f) for f in fields if f in record}
+        filtered_records.append(filtered_record)
+
+    return json.dumps(filtered_records, indent=2)
+
+
+def format_records_csv(
+    records: list[dict],
+    fields: list[str],
+    show_header: bool = True,
+) -> str:
+    """
+    Format records as CSV.
+
+    Args:
+        records: List of trace records
+        fields: List of field names to include
+        show_header: Whether to include the header row
+
+    Returns:
+        CSV formatted string
+    """
+    if not records:
+        return ""
+
+    output = io.StringIO(newline="")
+    writer = csv.writer(output)
+
+    if show_header:
+        writer.writerow(fields)
+
+    for record in records:
+        row = [format_value(record.get(f, "")) for f in fields]
+        writer.writerow(row)
+
+    return output.getvalue().rstrip("\r\n").replace("\r\n", "\n").replace("\r", "")

--- a/python/cutracer/analysis/reader.py
+++ b/python/cutracer/analysis/reader.py
@@ -1,0 +1,67 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Trace reader for CUTracer analysis.
+
+This module provides the TraceReader class for reading and iterating
+over trace records from NDJSON files (plain or Zstd-compressed).
+"""
+
+import json
+from pathlib import Path
+from typing import Iterator, Union
+
+from cutracer.validation.compression import detect_compression, open_trace_file
+
+
+class TraceReader:
+    """
+    Reader for CUTracer trace files.
+
+    Supports NDJSON format with optional Zstd compression.
+    Provides efficient iteration over trace records.
+
+    Example:
+        >>> reader = TraceReader("trace.ndjson.zst")
+        >>> for record in reader.iter_records():
+        ...     print(record["sass"])
+    """
+
+    def __init__(self, file_path: Union[str, Path]) -> None:
+        """
+        Initialize the TraceReader.
+
+        Args:
+            file_path: Path to the trace file (.ndjson or .ndjson.zst)
+
+        Raises:
+            FileNotFoundError: If the file does not exist
+        """
+        self.file_path = Path(file_path)
+
+        if not self.file_path.exists():
+            raise FileNotFoundError(f"File not found: {self.file_path}")
+
+        self.compression = detect_compression(self.file_path)
+
+    def iter_records(self) -> Iterator[dict]:
+        """
+        Iterate over all trace records in the file.
+
+        Yields:
+            dict: Each trace record as a dictionary
+
+        Raises:
+            json.JSONDecodeError: If a line contains invalid JSON
+
+        Example:
+            >>> reader = TraceReader("trace.ndjson")
+            >>> for record in reader.iter_records():
+            ...     process(record)
+        """
+        with open_trace_file(self.file_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                yield json.loads(line)

--- a/python/cutracer/cli.py
+++ b/python/cutracer/cli.py
@@ -10,6 +10,7 @@ import sys
 from importlib.metadata import PackageNotFoundError, version
 
 import click
+from cutracer.analysis.cli import analyze_command
 from cutracer.validation.cli import validate_command
 
 
@@ -37,6 +38,7 @@ def main() -> None:
 
 
 # Register subcommands
+main.add_command(analyze_command)
 main.add_command(validate_command)
 
 

--- a/python/tests/test_analyze_cli.py
+++ b/python/tests/test_analyze_cli.py
@@ -1,0 +1,105 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Unit tests for analyze CLI command.
+"""
+
+import unittest
+
+from click.testing import CliRunner
+from cutracer.cli import main
+from tests.test_base import BaseValidationTest, REG_TRACE_NDJSON, REG_TRACE_NDJSON_ZST
+
+
+class TestAnalyzeCommand(BaseValidationTest):
+    """Tests for analyze CLI command."""
+
+    def setUp(self):
+        super().setUp()
+        self.runner = CliRunner()
+
+    def test_analyze_help(self):
+        """Test analyze --help shows usage information."""
+        result = self.runner.invoke(main, ["analyze", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Analyze trace data", result.output)
+        self.assertIn("--head", result.output)
+        self.assertIn("--tail", result.output)
+        self.assertIn("--filter", result.output)
+
+    def test_analyze_default_head(self):
+        """Test analyze with default head (10 records)."""
+        result = self.runner.invoke(main, ["analyze", str(REG_TRACE_NDJSON)])
+        self.assertEqual(result.exit_code, 0)
+        # Should have header + 10 data rows = 11 lines
+        lines = [line for line in result.output.strip().split("\n") if line]
+        self.assertEqual(len(lines), 11)
+
+    def test_analyze_custom_head(self):
+        """Test analyze with custom head value."""
+        result = self.runner.invoke(
+            main, ["analyze", str(REG_TRACE_NDJSON), "--head", "5"]
+        )
+        self.assertEqual(result.exit_code, 0)
+        lines = [line for line in result.output.strip().split("\n") if line]
+        self.assertEqual(len(lines), 6)  # header + 5 data rows
+
+    def test_analyze_tail(self):
+        """Test analyze with tail option."""
+        result = self.runner.invoke(
+            main, ["analyze", str(REG_TRACE_NDJSON), "--tail", "3"]
+        )
+        self.assertEqual(result.exit_code, 0)
+        lines = [line for line in result.output.strip().split("\n") if line]
+        self.assertEqual(len(lines), 4)  # header + 3 data rows
+
+    def test_analyze_zst_file(self):
+        """Test analyze with Zstd-compressed file."""
+        result = self.runner.invoke(
+            main, ["analyze", str(REG_TRACE_NDJSON_ZST), "--head", "5"]
+        )
+        self.assertEqual(result.exit_code, 0)
+        lines = [line for line in result.output.strip().split("\n") if line]
+        self.assertEqual(len(lines), 6)
+
+    def test_analyze_filter(self):
+        """Test analyze with filter expression."""
+        result = self.runner.invoke(
+            main,
+            ["analyze", str(REG_TRACE_NDJSON), "--filter", "warp=0", "--head", "5"],
+        )
+        self.assertEqual(result.exit_code, 0)
+        # All displayed records should have warp=0
+        # Check that output contains "0" in the warp column
+        self.assertIn("0", result.output)
+
+    def test_analyze_filter_invalid(self):
+        """Test analyze with invalid filter expression."""
+        result = self.runner.invoke(
+            main, ["analyze", str(REG_TRACE_NDJSON), "--filter", "invalid"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Invalid filter expression", result.output)
+
+    def test_analyze_nonexistent_file(self):
+        """Test analyze with non-existent file."""
+        result = self.runner.invoke(main, ["analyze", "/nonexistent/file.ndjson"])
+        self.assertNotEqual(result.exit_code, 0)
+
+    def test_analyze_empty_file(self):
+        """Test analyze with empty file."""
+        empty_file = self.create_temp_file("empty.ndjson", "")
+        result = self.runner.invoke(main, ["analyze", str(empty_file)])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("No records found", result.output)
+
+    def test_analyze_short_options(self):
+        """Test analyze with short option names."""
+        result = self.runner.invoke(
+            main, ["analyze", str(REG_TRACE_NDJSON), "-n", "3", "-f", "warp=0"]
+        )
+        self.assertEqual(result.exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_formatters.py
+++ b/python/tests/test_formatters.py
@@ -1,0 +1,209 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Unit tests for formatters module.
+"""
+
+import json
+import unittest
+
+from cutracer.analysis.formatters import (
+    DEFAULT_FIELDS,
+    format_records_csv,
+    format_records_json,
+    format_records_table,
+    format_value,
+    get_display_fields,
+)
+
+
+class TestFormatValue(unittest.TestCase):
+    """Tests for format_value function."""
+
+    def test_format_value_none(self):
+        """Test None returns empty string."""
+        self.assertEqual(format_value(None), "")
+
+    def test_format_value_bool_true(self):
+        """Test True returns lowercase 'true'."""
+        self.assertEqual(format_value(True), "true")
+
+    def test_format_value_bool_false(self):
+        """Test False returns lowercase 'false'."""
+        self.assertEqual(format_value(False), "false")
+
+    def test_format_value_int(self):
+        """Test int returns string representation."""
+        self.assertEqual(format_value(42), "42")
+
+    def test_format_value_str(self):
+        """Test string returns as-is."""
+        self.assertEqual(format_value("hello"), "hello")
+
+    def test_format_value_list(self):
+        """Test list returns bracketed comma-separated values."""
+        self.assertEqual(format_value([1, 2, 3]), "[1,2,3]")
+
+    def test_format_value_empty_list(self):
+        """Test empty list returns empty brackets."""
+        self.assertEqual(format_value([]), "[]")
+
+    def test_format_value_dict(self):
+        """Test dict returns JSON string."""
+        result = format_value({"a": 1})
+        self.assertEqual(result, '{"a": 1}')
+
+
+class TestGetDisplayFields(unittest.TestCase):
+    """Tests for get_display_fields function."""
+
+    def test_get_display_fields_default(self):
+        """Test default fields when none requested."""
+        records = [{"warp": 0, "pc": "0x100", "sass": "NOP ;", "extra": "data"}]
+        fields = get_display_fields(records)
+        self.assertEqual(fields, ["warp", "pc", "sass"])
+
+    def test_get_display_fields_requested(self):
+        """Test user-specified fields are used."""
+        records = [{"warp": 0, "pc": "0x100", "sass": "NOP ;"}]
+        fields = get_display_fields(records, "warp,sass")
+        self.assertEqual(fields, ["warp", "sass"])
+
+    def test_get_display_fields_with_spaces(self):
+        """Test fields with spaces are trimmed."""
+        records = [{"warp": 0, "pc": "0x100"}]
+        fields = get_display_fields(records, " warp , pc ")
+        self.assertEqual(fields, ["warp", "pc"])
+
+    def test_get_display_fields_empty_records(self):
+        """Test empty records returns DEFAULT_FIELDS."""
+        fields = get_display_fields([])
+        self.assertEqual(fields, DEFAULT_FIELDS)
+
+    def test_get_display_fields_missing_default(self):
+        """Test only available default fields are returned."""
+        records = [{"warp": 0, "custom": "value"}]  # no 'pc' or 'sass'
+        fields = get_display_fields(records)
+        self.assertEqual(fields, ["warp"])
+
+
+class TestFormatRecordsTable(unittest.TestCase):
+    """Tests for format_records_table function."""
+
+    def test_format_table_empty_records(self):
+        """Test empty records returns message."""
+        result = format_records_table([], ["warp", "pc"])
+        self.assertEqual(result, "No records found.")
+
+    def test_format_table_with_header(self):
+        """Test table with header row."""
+        records = [{"warp": 0, "pc": "0x100"}]
+        result = format_records_table(records, ["warp", "pc"], show_header=True)
+        lines = result.split("\n")
+        self.assertEqual(len(lines), 2)
+        self.assertIn("WARP", lines[0])
+        self.assertIn("PC", lines[0])
+        self.assertIn("0", lines[1])
+        self.assertIn("0x100", lines[1])
+
+    def test_format_table_without_header(self):
+        """Test table without header row."""
+        records = [{"warp": 0, "pc": "0x100"}]
+        result = format_records_table(records, ["warp", "pc"], show_header=False)
+        lines = result.split("\n")
+        self.assertEqual(len(lines), 1)
+        self.assertNotIn("WARP", result)
+
+    def test_format_table_column_alignment(self):
+        """Test columns are aligned by width."""
+        records = [
+            {"warp": 0, "sass": "NOP ;"},
+            {"warp": 123, "sass": "EXIT ;"},
+        ]
+        result = format_records_table(records, ["warp", "sass"], show_header=True)
+        lines = result.split("\n")
+        # All lines should have consistent column positions
+        self.assertEqual(len(lines), 3)  # header + 2 data rows
+
+    def test_format_table_missing_field(self):
+        """Test missing field shows empty string."""
+        records = [{"warp": 0}]  # no 'pc' field
+        result = format_records_table(records, ["warp", "pc"], show_header=False)
+        self.assertIn("0", result)
+
+
+class TestFormatRecordsJson(unittest.TestCase):
+    """Tests for format_records_json function."""
+
+    def test_format_json_empty_records(self):
+        """Test empty records returns empty array."""
+        result = format_records_json([], ["warp"])
+        self.assertEqual(result, "[]")
+
+    def test_format_json_single_record(self):
+        """Test single record formatting."""
+        records = [{"warp": 0, "pc": "0x100", "extra": "ignored"}]
+        result = format_records_json(records, ["warp", "pc"])
+        parsed = json.loads(result)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["warp"], 0)
+        self.assertEqual(parsed[0]["pc"], "0x100")
+        self.assertNotIn("extra", parsed[0])
+
+    def test_format_json_multiple_records(self):
+        """Test multiple records formatting."""
+        records = [{"warp": 0}, {"warp": 1}]
+        result = format_records_json(records, ["warp"])
+        parsed = json.loads(result)
+        self.assertEqual(len(parsed), 2)
+
+    def test_format_json_filters_fields(self):
+        """Test only requested fields are included."""
+        records = [{"warp": 0, "pc": "0x100", "sass": "NOP ;"}]
+        result = format_records_json(records, ["warp"])
+        parsed = json.loads(result)
+        self.assertEqual(list(parsed[0].keys()), ["warp"])
+
+
+class TestFormatRecordsCsv(unittest.TestCase):
+    """Tests for format_records_csv function."""
+
+    def test_format_csv_empty_records(self):
+        """Test empty records returns empty string."""
+        result = format_records_csv([], ["warp"])
+        self.assertEqual(result, "")
+
+    def test_format_csv_with_header(self):
+        """Test CSV with header row."""
+        records = [{"warp": 0, "pc": "0x100"}]
+        result = format_records_csv(records, ["warp", "pc"], show_header=True)
+        lines = result.split("\n")
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(lines[0], "warp,pc")
+        self.assertEqual(lines[1], "0,0x100")
+
+    def test_format_csv_without_header(self):
+        """Test CSV without header row."""
+        records = [{"warp": 0, "pc": "0x100"}]
+        result = format_records_csv(records, ["warp", "pc"], show_header=False)
+        lines = result.split("\n")
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0], "0,0x100")
+
+    def test_format_csv_escapes_comma(self):
+        """Test CSV properly escapes values with commas."""
+        records = [{"sass": "MOV R0, R1 ;"}]
+        result = format_records_csv(records, ["sass"], show_header=False)
+        # CSV should quote the value containing comma
+        self.assertIn('"', result)
+
+    def test_format_csv_multiple_records(self):
+        """Test CSV with multiple records."""
+        records = [{"warp": 0}, {"warp": 1}, {"warp": 2}]
+        result = format_records_csv(records, ["warp"], show_header=True)
+        lines = result.split("\n")
+        self.assertEqual(len(lines), 4)  # 1 header + 3 data
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_reader.py
+++ b/python/tests/test_reader.py
@@ -1,0 +1,160 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Unit tests for TraceReader class.
+"""
+
+import json
+import types
+import unittest
+
+from cutracer.analysis import TraceReader
+from tests.test_base import (
+    BaseValidationTest,
+    REG_TRACE_NDJSON,
+    REG_TRACE_NDJSON_RECORD_COUNT,
+    REG_TRACE_NDJSON_ZST,
+    REG_TRACE_NDJSON_ZST_RECORD_COUNT,
+)
+
+
+class TestTraceReaderInit(BaseValidationTest):
+    """Tests for TraceReader initialization."""
+
+    def test_init_with_ndjson_file(self):
+        """Test initialization with a plain NDJSON file."""
+        reader = TraceReader(REG_TRACE_NDJSON)
+        self.assertEqual(reader.file_path, REG_TRACE_NDJSON)
+        self.assertEqual(reader.compression, "none")
+
+    def test_init_with_zst_file(self):
+        """Test initialization with a Zstd-compressed NDJSON file."""
+        reader = TraceReader(REG_TRACE_NDJSON_ZST)
+        self.assertEqual(reader.file_path, REG_TRACE_NDJSON_ZST)
+        self.assertEqual(reader.compression, "zstd")
+
+    def test_init_with_string_path(self):
+        """Test initialization with a string path."""
+        reader = TraceReader(str(REG_TRACE_NDJSON))
+        self.assertEqual(reader.file_path, REG_TRACE_NDJSON)
+
+    def test_init_with_nonexistent_file(self):
+        """Test that FileNotFoundError is raised for non-existent file."""
+        with self.assertRaises(FileNotFoundError):
+            TraceReader("/nonexistent/path/file.ndjson")
+
+
+class TestTraceReaderIterRecords(BaseValidationTest):
+    """Tests for TraceReader.iter_records() method."""
+
+    def test_iter_records_ndjson(self):
+        """Test iterating over records in a plain NDJSON file."""
+        reader = TraceReader(REG_TRACE_NDJSON)
+        records = list(reader.iter_records())
+
+        self.assertEqual(len(records), REG_TRACE_NDJSON_RECORD_COUNT)
+
+        # Verify first record structure
+        first_record = records[0]
+        self.assertIn("type", first_record)
+        self.assertIn("warp", first_record)
+        self.assertIn("sass", first_record)
+        self.assertEqual(first_record["type"], "reg_trace")
+
+    def test_iter_records_zst(self):
+        """Test iterating over records in a Zstd-compressed NDJSON file."""
+        reader = TraceReader(REG_TRACE_NDJSON_ZST)
+        records = list(reader.iter_records())
+
+        self.assertEqual(len(records), REG_TRACE_NDJSON_ZST_RECORD_COUNT)
+
+    def test_iter_records_zst_has_valid_structure(self):
+        """Test that Zstd compressed file records have valid structure."""
+        reader = TraceReader(REG_TRACE_NDJSON_ZST)
+        records = list(reader.iter_records())
+
+        self.assertGreater(len(records), 0)
+
+        # Verify record structure
+        first_record = records[0]
+        self.assertIn("type", first_record)
+        self.assertIn("warp", first_record)
+        self.assertIn("sass", first_record)
+
+    def test_iter_records_is_generator(self):
+        """Test that iter_records returns a generator (lazy evaluation)."""
+        reader = TraceReader(REG_TRACE_NDJSON)
+        result = reader.iter_records()
+
+        # Should be a generator, not a list
+        self.assertIsInstance(result, types.GeneratorType)
+
+    def test_iter_records_can_iterate_multiple_times(self):
+        """Test that iter_records can be called multiple times."""
+        reader = TraceReader(REG_TRACE_NDJSON)
+
+        # First iteration
+        records1 = list(reader.iter_records())
+        # Second iteration
+        records2 = list(reader.iter_records())
+
+        self.assertEqual(len(records1), len(records2))
+        self.assertEqual(records1[0], records2[0])
+
+
+class TestTraceReaderEdgeCases(BaseValidationTest):
+    """Edge case tests for TraceReader."""
+
+    def test_empty_file(self):
+        """Test reading an empty file."""
+        filepath = self.create_temp_file("empty.ndjson", "")
+
+        reader = TraceReader(filepath)
+        records = list(reader.iter_records())
+
+        self.assertEqual(len(records), 0)
+
+    def test_single_record_file(self):
+        """Test reading a file with a single record."""
+        content = '{"type": "reg_trace", "warp": 0, "sass": "NOP ;"}\n'
+        filepath = self.create_temp_file("single.ndjson", content)
+
+        reader = TraceReader(filepath)
+        records = list(reader.iter_records())
+
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["type"], "reg_trace")
+
+    def test_empty_lines_skipped(self):
+        """Test that empty lines in the file are skipped."""
+        content = (
+            '{"type": "reg_trace", "warp": 0}\n\n{"type": "reg_trace", "warp": 1}\n'
+        )
+        filepath = self.create_temp_file("test.ndjson", content)
+
+        reader = TraceReader(filepath)
+        records = list(reader.iter_records())
+
+        self.assertEqual(len(records), 2)
+        self.assertEqual(records[0]["warp"], 0)
+        self.assertEqual(records[1]["warp"], 1)
+
+    def test_invalid_json_raises_error(self):
+        """Test that invalid JSON raises JSONDecodeError."""
+        content = '{"type": "reg_trace"}\n{invalid json}\n'
+        filepath = self.create_temp_file("invalid.ndjson", content)
+
+        reader = TraceReader(filepath)
+        iterator = reader.iter_records()
+
+        # First record should work
+        first = next(iterator)
+        self.assertEqual(first["type"], "reg_trace")
+
+        # Second record should raise
+        with self.assertRaises(json.JSONDecodeError):
+            next(iterator)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
Add the `analyze` subcommand to the CUTracer CLI for analyzing trace files.

This command provides:
- `--head/-n`: Show first N records (default: 10)
- `--tail/-t`: Show last N records (overrides --head)
- `--filter/-f`: Filter records by field value (e.g., "warp=24")

The command reads NDJSON trace files (plain or Zstd-compressed) and displays
records in a formatted table. It leverages the TraceReader, parse_filter_expr,
select_records, and formatters modules from previous PRs.

Usage examples:
```
cutracer analyze trace.ndjson
cutracer analyze trace.ndjson --head 20
cutracer analyze trace.ndjson --tail 5
cutracer analyze trace.ndjson --filter "warp=24"
```

This is PR4 in a series adding trace analysis functionality to CUTracer.

Differential Revision: D90600728


