### PR TITLE
Improve Makefile build experience and fix path style

### DIFF
--- a/scripts/install_cuda.sh
+++ b/scripts/install_cuda.sh
@@ -38,6 +38,7 @@ declare -A CUDA_FULL_VERSION=(
   ["12.8"]="12.8.1"
   ["12.9"]="12.9.1"
   ["13.0"]="13.0.2"
+  ["13.1"]="13.1.1"
 )
 
 declare -A CUDA_RUNFILE=(
@@ -45,6 +46,7 @@ declare -A CUDA_RUNFILE=(
   ["12.8"]="cuda_12.8.1_570.124.06_linux"
   ["12.9"]="cuda_12.9.1_575.57.08_linux"
   ["13.0"]="cuda_13.0.2_580.95.05_linux"
+  ["13.1"]="cuda_13.1.1_590.48.01_linux"
 )
 
 declare -A CUDNN_VERSIONS=(
@@ -52,6 +54,7 @@ declare -A CUDNN_VERSIONS=(
   ["12.8"]="9.15.1.9"
   ["12.9"]="9.15.1.9"
   ["13.0"]="9.15.1.9"
+  ["13.1"]="9.15.1.9"
 )
 
 declare -A CUDA_MAJOR=(
@@ -59,6 +62,7 @@ declare -A CUDA_MAJOR=(
   ["12.8"]="12"
   ["12.9"]="12"
   ["13.0"]="13"
+  ["13.1"]="13"
 )
 
 # Create temporary directory


### PR DESCRIPTION
Summary:
Improve the Makefile build experience with the following changes:

1. Add `-Wno-deprecated-gpu-targets` flag to all NVCC compilation commands to suppress warnings about deprecated GPU architectures.

2. Add a build success message at the end of compilation to provide clear feedback when the build completes.

3. Standardize directory variable style throughout the Makefile. Changed `SRC_DIR`, `OBJ_DIR`, and `LIB_DIR` from trailing-slash style (`lib/`) to no-trailing-slash style (`lib`), and updated all usages to use explicit path separators (`$(LIB_DIR)/file` instead of `$(LIB_DIR)file`). This fixes the double-slash issue in the build output path (`lib//cutracer.so` → `lib/cutracer.so`).

Differential Revision: D91634826


