### PR TITLE
Rename mem_trace to mem_addr_trace (breaking change)

### DIFF
--- a/include/analysis.h
+++ b/include/analysis.h
@@ -215,7 +215,7 @@ struct CTXstate {
   time_t last_hang_check_time;
 
   // Pending mem traces per warp for out-of-order arrival (mem before reg)
-  std::unordered_map<WarpKey, std::deque<mem_access_t>, WarpKey::Hash> pending_mem_by_warp;
+  std::unordered_map<WarpKey, std::deque<mem_addr_access_t>, WarpKey::Hash> pending_mem_by_warp;
 
   // Per-warp activity timestamps for inactive cleanup
   std::unordered_map<WarpKey, time_t, WarpKey::Hash> last_seen_time_by_warp;

--- a/include/common.h
+++ b/include/common.h
@@ -15,7 +15,7 @@
 #include <stdint.h>
 
 /* Message type enum to identify different message types */
-typedef enum { MSG_TYPE_REG_INFO = 0, MSG_TYPE_MEM_ACCESS = 1, MSG_TYPE_OPCODE_ONLY = 2 } message_type_t;
+typedef enum { MSG_TYPE_REG_INFO = 0, MSG_TYPE_MEM_ADDR_ACCESS = 1, MSG_TYPE_OPCODE_ONLY = 2 } message_type_t;
 
 /* Common header for all message types */
 typedef struct {
@@ -44,7 +44,7 @@ typedef struct {
 
 /* Based on NVIDIA mem_trace example with Meta modifications for message type support */
 typedef struct {
-  message_header_t header;  // Common header with type=MSG_TYPE_MEM_ACCESS
+  message_header_t header;  // Common header with type=MSG_TYPE_MEM_ADDR_ACCESS
   uint64_t kernel_launch_id;
   int cta_id_x;
   int cta_id_y;
@@ -53,7 +53,7 @@ typedef struct {
   int warp_id;
   int opcode_id;
   uint64_t addrs[32];
-} mem_access_t;
+} mem_addr_access_t;
 
 /**
  * @brief A lightweight data packet for instruction histogram analysis.

--- a/include/instrument.h
+++ b/include/instrument.h
@@ -15,10 +15,10 @@
  * @brief Instrumentation types for different data collection modes
  */
 enum class InstrumentType {
-  OPCODE_ONLY,  // Lightweight: only collect opcode information
-  REG_TRACE,    // Medium: collect register values
-  MEM_TRACE,    // Heavy: collect memory access information
-  RANDOM_DELAY  // Inject random delays on synchronization instructions
+  OPCODE_ONLY,     // Lightweight: only collect opcode information
+  REG_TRACE,       // Medium: collect register values
+  MEM_ADDR_TRACE,  // Heavy: collect memory access information (address only)
+  RANDOM_DELAY     // Inject random delays on synchronization instructions
 };
 
 /**
@@ -68,7 +68,7 @@ void instrument_register_trace(Instr* instr, int opcode_id, CTXstate* ctx_state,
  * @param ctx_state The context state containing channel information
  * @param mref_idx Memory reference index
  */
-void instrument_memory_trace(Instr* instr, int opcode_id, CTXstate* ctx_state, int mref_idx);
+void instrument_memory_addr_trace(Instr* instr, int opcode_id, CTXstate* ctx_state, int mref_idx);
 
 /**
  * @brief Insert random delay instrumentation for synchronization instructions

--- a/include/trace_writer.h
+++ b/include/trace_writer.h
@@ -22,7 +22,7 @@
  * @brief Rich trace record combining GPU trace data with metadata.
  *
  * This structure acts as an intermediate layer between raw GPU communication
- * structs (reg_info_t, mem_access_t, opcode_only_t) and the JSON output format.
+ * structs (reg_info_t, mem_addr_access_t, opcode_only_t) and the JSON output format.
  *
  * Benefits:
  * - GPU communication protocol remains unchanged
@@ -80,7 +80,7 @@ struct TraceRecord {
    */
   union {
     const reg_info_t* reg_info;
-    const mem_access_t* mem_access;
+    const mem_addr_access_t* mem_access;
     const opcode_only_t* opcode_only;
   } data;
 
@@ -102,16 +102,16 @@ struct TraceRecord {
   }
 
   /**
-   * @brief Create a TraceRecord for mem_access_t.
+   * @brief Create a TraceRecord for mem_addr_access_t.
    */
   static TraceRecord create_mem_trace(CUcontext ctx, const std::string& sass, uint64_t trace_idx, uint64_t ts,
-                                      const mem_access_t* mem) {
+                                      const mem_addr_access_t* mem) {
     TraceRecord record;
     record.context = ctx;
     record.sass_instruction = sass;
     record.trace_index = trace_idx;
     record.timestamp = ts;
-    record.type = MSG_TYPE_MEM_ACCESS;
+    record.type = MSG_TYPE_MEM_ADDR_ACCESS;
     record.data.mem_access = mem;
     return record;
   }
@@ -250,9 +250,9 @@ class TraceWriter {
   void serialize_reg_info(nlohmann::json& j, const reg_info_t* reg);
 
   /**
-   * @brief Serialize mem_access_t fields to JSON object.
+   * @brief Serialize mem_addr_access_t fields to JSON object.
    */
-  void serialize_mem_access(nlohmann::json& j, const mem_access_t* mem);
+  void serialize_mem_access(nlohmann::json& j, const mem_addr_access_t* mem);
 
   /**
    * @brief Serialize opcode_only_t fields to JSON object.

--- a/src/analysis.cu
+++ b/src/analysis.cu
@@ -410,8 +410,8 @@ static uint64_t get_kernel_launch_id(const message_header_t* header) {
       return ((const reg_info_t*)header)->kernel_launch_id;
     case MSG_TYPE_OPCODE_ONLY:
       return ((const opcode_only_t*)header)->kernel_launch_id;
-    case MSG_TYPE_MEM_ACCESS:
-      return ((const mem_access_t*)header)->kernel_launch_id;
+    case MSG_TYPE_MEM_ADDR_ACCESS:
+      return ((const mem_addr_access_t*)header)->kernel_launch_id;
     default:
       return 0;  // Invalid/unknown message type - no kernel ID available
   }
@@ -990,7 +990,7 @@ static void check_kernel_hang(CTXstate* ctx_state, uint64_t current_kernel_launc
  * Meta's enhancements transform this from a simple single-purpose function to a
  * versatile multi-analysis pipeline:
  *  - **Generic Message-Passing System**: The original function only handled one
- *    data type (`mem_access_t`). This version uses a `message_header_t` to
+ *    data type (`mem_addr_access_t`). This version uses a `message_header_t` to
  *    identify different packet types (`reg_info_t`, `opcode_only_t`, etc.) and
  *    dispatch them to the appropriate analysis logic.
  *  - **Instruction Histogram Analysis**: It contains the complete host-side logic
@@ -1148,8 +1148,8 @@ void* recv_thread_fun(void* args) {
           }
           num_processed_bytes += sizeof(opcode_only_t);
 
-        } else if (header->type == MSG_TYPE_MEM_ACCESS) {
-          mem_access_t* mem = (mem_access_t*)&recv_buffer[num_processed_bytes];
+        } else if (header->type == MSG_TYPE_MEM_ADDR_ACCESS) {
+          mem_addr_access_t* mem = (mem_addr_access_t*)&recv_buffer[num_processed_bytes];
 
           // Get SASS string for trace output
           std::string sass_str_cpp;
@@ -1171,7 +1171,7 @@ void* recv_thread_fun(void* args) {
             ctx_state->trace_writer->write_trace(record);
           }
 
-          num_processed_bytes += sizeof(mem_access_t);
+          num_processed_bytes += sizeof(mem_addr_access_t);
         } else {
           // Unknown message type, print error and break loop
           // TODO: handle error message in our current log mechanism

--- a/src/cutracer.cu
+++ b/src/cutracer.cu
@@ -223,8 +223,8 @@ bool instrument_function_if_needed(CUcontext ctx, CUfunction func) {
           }
 
           // Use new instrumentation interface for memory tracing
-          if (is_instrument_type_enabled(InstrumentType::MEM_TRACE)) {
-            instrument_memory_trace(instr, opcode_id, ctx_state, mref_idx);
+          if (is_instrument_type_enabled(InstrumentType::MEM_ADDR_TRACE)) {
+            instrument_memory_addr_trace(instr, opcode_id, ctx_state, mref_idx);
           }
           mref_idx++;
         }

--- a/src/env_config.cu
+++ b/src/env_config.cu
@@ -142,9 +142,9 @@ void init_instrumentation(const std::string& instrument_str) {
     enabled_instrument_types.insert(InstrumentType::REG_TRACE);
     loprintf("  - Enabled: reg_trace (register value tracing)\n");
   }
-  if (instrument_str.find("mem_trace") != std::string::npos) {
-    enabled_instrument_types.insert(InstrumentType::MEM_TRACE);
-    loprintf("  - Enabled: mem_trace (memory access tracing)\n");
+  if (instrument_str.find("mem_addr_trace") != std::string::npos) {
+    enabled_instrument_types.insert(InstrumentType::MEM_ADDR_TRACE);
+    loprintf("  - Enabled: mem_addr_trace (memory access address tracing)\n");
   }
   if (instrument_str.find("random_delay") != std::string::npos) {
     enabled_instrument_types.insert(InstrumentType::RANDOM_DELAY);
@@ -252,7 +252,7 @@ void init_config_from_env() {
                  "End of the instruction interval where to apply instrumentation");
   std::string instrument_str;
   get_var_str(instrument_str, "CUTRACER_INSTRUMENT", "",
-              "Instrumentation types to enable (opcode_only,reg_trace,mem_trace)");
+              "Instrumentation types to enable (opcode_only,reg_trace,mem_addr_trace)");
   std::string kernel_filters_env;
   get_var_str(kernel_filters_env, "KERNEL_FILTERS", "", "Kernel name filters");
   std::string analysis_str;

--- a/src/inject_funcs.cu
+++ b/src/inject_funcs.cu
@@ -87,9 +87,9 @@ extern "C" __device__ __noinline__ void instrument_mem(int pred, int opcode_id, 
   const int laneid = get_laneid();
   const int first_laneid = __ffs(active_mask) - 1;
 
-  mem_access_t ma;
+  mem_addr_access_t ma;
 
-  ma.header.type = MSG_TYPE_MEM_ACCESS;
+  ma.header.type = MSG_TYPE_MEM_ADDR_ACCESS;
 
   /* collect memory address information from other threads */
   for (int i = 0; i < 32; i++) {
@@ -107,7 +107,7 @@ extern "C" __device__ __noinline__ void instrument_mem(int pred, int opcode_id, 
   /* first active lane pushes information on the channel */
   if (first_laneid == laneid) {
     ChannelDev* channel_dev = (ChannelDev*)pchannel_dev;
-    channel_dev->push(&ma, sizeof(mem_access_t));
+    channel_dev->push(&ma, sizeof(mem_addr_access_t));
   }
 }
 

--- a/src/instrument.cu
+++ b/src/instrument.cu
@@ -101,8 +101,11 @@ void instrument_register_trace(Instr* instr, int opcode_id, CTXstate* ctx_state,
  *    instruction's program counter (PC) alongside the memory address. This
  *    allows for more detailed analysis by linking each memory access to a
  *    specific kernel launch and instruction.
+ *
+ * Note: This function implements `mem_addr_trace` mode which only captures
+ * memory addresses, not values. For value tracing, use `mem_value_trace` mode.
  */
-void instrument_memory_trace(Instr* instr, int opcode_id, CTXstate* ctx_state, int mref_idx) {
+void instrument_memory_addr_trace(Instr* instr, int opcode_id, CTXstate* ctx_state, int mref_idx) {
   /* insert call to the instrumentation function with its
    * arguments */
   nvbit_insert_call(instr, "instrument_mem", IPOINT_BEFORE);
@@ -169,4 +172,3 @@ void instrument_random_delay(Instr* instr, uint32_t max_delay_ns) {
   /* delay in nanoseconds - generated on host, unique per instruction */
   nvbit_add_call_arg_const_val32(instr, delay_ns);
 }
-

--- a/src/trace_writer.cpp
+++ b/src/trace_writer.cpp
@@ -280,7 +280,7 @@ void TraceWriter::serialize_reg_info(nlohmann::json& j, const reg_info_t* reg) {
   }
 }
 
-void TraceWriter::serialize_mem_access(nlohmann::json& j, const mem_access_t* mem) {
+void TraceWriter::serialize_mem_access(nlohmann::json& j, const mem_addr_access_t* mem) {
   if (!mem) return;
 
   // Basic fields
@@ -344,8 +344,8 @@ void TraceWriter::write_text_format(const TraceRecord& record) {
       break;
     }
 
-    case MSG_TYPE_MEM_ACCESS: {
-      const mem_access_t* mem = record.data.mem_access;
+    case MSG_TYPE_MEM_ADDR_ACCESS: {
+      const mem_addr_access_t* mem = record.data.mem_access;
 
       // Print header
       fprintf(file_handle_, "CTX %p - kernel_launch_id %ld - CTA %d,%d,%d - warp %d - PC %ld - %s:\n", record.context,
@@ -394,8 +394,8 @@ void TraceWriter::write_json_format(const TraceRecord& record) {
       case MSG_TYPE_REG_INFO:
         j["type"] = "reg_trace";
         break;
-      case MSG_TYPE_MEM_ACCESS:
-        j["type"] = "mem_trace";
+      case MSG_TYPE_MEM_ADDR_ACCESS:
+        j["type"] = "mem_addr_trace";
         break;
       case MSG_TYPE_OPCODE_ONLY:
         j["type"] = "opcode_only";
@@ -427,7 +427,7 @@ void TraceWriter::write_json_format(const TraceRecord& record) {
       case MSG_TYPE_REG_INFO:
         serialize_reg_info(j, record.data.reg_info);
         break;
-      case MSG_TYPE_MEM_ACCESS:
+      case MSG_TYPE_MEM_ADDR_ACCESS:
         serialize_mem_access(j, record.data.mem_access);
         break;
       case MSG_TYPE_OPCODE_ONLY:


### PR DESCRIPTION
Summary:
Rename `mem_trace` to `mem_addr_trace` to form a clearer semantic symmetry with the upcoming `mem_value_trace` feature.

This is a breaking change that affects:
- Environment variable: `CUTRACER_INSTRUMENT=mem_trace` → `CUTRACER_INSTRUMENT=mem_addr_trace`
- JSON output type field: `"type": "mem_trace"` → `"type": "mem_addr_trace"`
- C++ types and enums: `mem_access_t` → `mem_addr_access_t`, `MSG_TYPE_MEM_ACCESS` → `MSG_TYPE_MEM_ADDR_ACCESS`, `MEM_TRACE` → `MEM_ADDR_TRACE`

Rationale:
- Naming symmetry: `addr` vs `value` makes the distinction clear
- Eliminates ambiguity: `mem_trace` could be misunderstood as recording complete memory information (including values)
- Low migration cost: Current user base is small, making this the optimal time for the breaking change

This is Diff 1 of 3 for the mem_value_trace feature implementation.

Differential Revision: D91924327


