### PR TITLE
Use a fixed delay value for  delay injection

### DIFF
--- a/include/env_config.h
+++ b/include/env_config.h
@@ -82,6 +82,5 @@ extern int trace_format_ndjson;
 // Default: 9 (good compression with reasonable speed)
 extern int zstd_compression_level;
 
-// Random delay max value in nanoseconds for mbarrier instrumentation
-// Default: 0 (disabled)
-extern uint32_t random_delay_max_ns;
+// Delay value in nanoseconds for random delay instrumentation
+extern uint32_t delay_ns;

--- a/include/instrument.h
+++ b/include/instrument.h
@@ -86,16 +86,15 @@ void instrument_memory_addr_trace(Instr* instr, int opcode_id, CTXstate* ctx_sta
 void instrument_memory_value_trace(Instr* instr, int opcode_id, CTXstate* ctx_state, int mref_idx, int mem_space);
 
 /**
- * @brief Insert random delay instrumentation for synchronization instructions
+ * @brief Instruments an instruction to inject a fixed delay.
  *
- * Injects a random delay before eligible synchronization instructions.
- * The delay is computed on the host side, so each instruction gets a unique
- * random value. This is useful for exposing potential race conditions.
+ * Inserts a call to the `instrument_delay` device function before the
+ * instruction. The delay value is a fixed value determined by CUTRACER_DELAY_NS.
  *
  * @param instr The instruction to instrument
- * @param max_delay_ns Maximum random delay in nanoseconds
+ * @param delay_ns Fixed delay in nanoseconds
  */
-void instrument_random_delay(Instr* instr, uint32_t max_delay_ns);
+void instrument_delay_injection(Instr* instr, uint32_t delay_ns);
 
 /**
  * @brief SASS instruction patterns for delay injection.

--- a/src/cutracer.cu
+++ b/src/cutracer.cu
@@ -241,10 +241,10 @@ bool instrument_function_if_needed(CUcontext ctx, CUfunction func) {
         instrument_register_trace(instr, opcode_id, ctx_state, operands);
       }
 
-      // Random delay instrumentation for synchronization instructions
+      // Delay instrumentation for synchronization instructions
       if (is_instrument_type_enabled(InstrumentType::RANDOM_DELAY) &&
           shouldInjectDelay(instr, DELAY_INJECTION_PATTERNS)) {
-        instrument_random_delay(instr, random_delay_max_ns);
+        instrument_delay_injection(instr, delay_ns);
       }
     }
 


### PR DESCRIPTION
Summary:
To move random delay control to a higher level, as a preparation step, make the following changes:
- Remove the inner-function randomization logic.
- Rename `CUTRACER_RANDOM_DELAY_NS` to `CUTRACER_DELAY_NS`.
- Switch to a fixed delay value for injection by renaming `random_delay_max_ns` to `delay_ns`

Differential Revision: D92201100


