### PR TITLE
Implement per-launch TraceWriter for independent trace files

### DIFF
--- a/include/analysis.h
+++ b/include/analysis.h
@@ -10,7 +10,9 @@
 #include <ctime>
 #include <deque>
 #include <map>
+#include <mutex>
 #include <set>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -231,8 +233,11 @@ struct CTXstate {
   // Warp statistics tracking per kernel launch
   std::unordered_map<uint64_t, KernelWarpStats> kernel_warp_tracking;
 
-  // TraceWriter for JSON output (mode 1/2), nullptr if mode 0 (text)
-  TraceWriter* trace_writer = nullptr;
+  // Per-launch TraceWriter map for JSON output (mode 1/2)
+  // Maps kernel_launch_id -> TraceWriter*
+  // Each kernel launch gets its own trace file
+  std::map<uint64_t, TraceWriter*> trace_writers;
+  mutable std::shared_mutex writers_mutex;
 
   // Per-kernel trace index counter (monotonically increasing)
   // Maps kernel_launch_id -> current trace_index

--- a/include/env_config.h
+++ b/include/env_config.h
@@ -63,6 +63,9 @@ void init_config_from_env();
 // Check if a specific instrumentation type is enabled
 bool is_instrument_type_enabled(InstrumentType type);
 
+// Check if any instrumentation type is enabled
+bool has_any_instrumentation_enabled();
+
 // Check if a specific analysis type is enabled
 bool is_analysis_type_enabled(AnalysisType type);
 

--- a/src/env_config.cu
+++ b/src/env_config.cu
@@ -244,6 +244,21 @@ bool is_instrument_type_enabled(InstrumentType type) {
   return enabled_instrument_types.count(type);
 }
 
+/**
+ * @brief Check if any instrumentation type is enabled
+ *
+ * This function checks if CUTRACER_INSTRUMENT was set to a non-empty value,
+ * meaning at least one instrumentation type (reg_trace, mem_addr_trace, etc.)
+ * is enabled. This is used to decide whether to create TraceWriter instances -
+ * if no instrumentation is enabled, there's no point creating trace files
+ * since they will be empty.
+ *
+ * @return true if at least one instrumentation type is enabled
+ */
+bool has_any_instrumentation_enabled() {
+  return !enabled_instrument_types.empty();
+}
+
 bool is_analysis_type_enabled(AnalysisType type) {
   return enabled_analysis_types.count(type);
 }

--- a/tests/vectoradd/vectoradd.cu
+++ b/tests/vectoradd/vectoradd.cu
@@ -86,7 +86,9 @@ int main(int argc, char* argv[]) {
   double sum = 0;
   for (i = 0; i < n; i++) sum += h_c[i];
   printf("Final sum = %f; sum/n = %f (should be ~1)\n", sum, sum / n);
-
+  // call kernel again
+  CUDA_SAFECALL((vecAdd<<<gridSize, blockSize>>>(d_a, d_b, d_c, n)));
+  printf("Second call to kernel\n");
   // Release device memory
   cudaFree(d_a);
   cudaFree(d_b);


### PR DESCRIPTION
Summary:
When a kernel is launched multiple times, each launch now generates its own independent trace file instead of mixing all traces into a single file.

**Problem:**
Previously, CUTracer used a single TraceWriter per CUDA context. When a kernel was launched multiple times (e.g., in training loops), all trace data was mixed into one file with different `grid_launch_id` values, making it difficult to analyze individual kernel executions.

**Solution:**
Implement a per-launch TraceWriter map that creates an independent TraceWriter for each kernel launch:

1. **Data structure change**: Replace `TraceWriter* trace_writer` with `std::map<uint64_t, TraceWriter*> trace_writers` protected by `std::shared_mutex`

2. **Writer lifecycle**:
   - Create a new TraceWriter in `enter_kernel_launch` for each launch
   - Use read-write locks for thread-safe concurrent access
   - Close previous writer in `recv_thread` when detecting launch_id change (leveraging kernel serialization + FIFO channel for implicit synchronization)
   - Fallback cleanup in `nvbit_at_ctx_term`

3. **CUDA Graph support**: Add TraceWriter creation in `nvbit_at_graph_node_launch`

4. **Prevent empty trace files**: Add `has_any_instrumentation_enabled()` function to check if any instrumentation type is enabled. TraceWriter is only created when:
   - `kernel_filters` is empty (user wants all kernels) AND `CUTRACER_INSTRUMENT` is set, OR
   - `kernel_filters` matches the kernel AND `CUTRACER_INSTRUMENT` is set
   
   This prevents creating empty trace files when running CUTracer without `CUTRACER_INSTRUMENT` set (e.g., when users only want to see kernel launch info in `cutracer_main.log`).

Differential Revision: D92223582


