### PR TITLE
Add CLI options for data race test script and update dependencies

### DIFF
--- a/install_third_party.sh
+++ b/install_third_party.sh
@@ -4,8 +4,8 @@
 # Script to download and install third-party dependencies for CUTracer
 #
 # Environment Variables:
-#   NVBIT_VERSION  - NVBit version (default: 1.7.6, or "latest" for latest release)
-#   JSON_VERSION   - nlohmann/json version (default: 3.11.3)
+#   NVBIT_VERSION  - NVBit version (or "latest" for latest release)
+#   JSON_VERSION   - nlohmann/json version
 #
 # Usage:
 #   ./install_third_party.sh                        # Use defaults
@@ -15,7 +15,7 @@
 # ============================================================
 # Configuration: Set default values if not provided
 # ============================================================
-NVBIT_VERSION="${NVBIT_VERSION:-1.7.6}"
+NVBIT_VERSION="${NVBIT_VERSION:-1.7.7.1}"
 JSON_VERSION="${JSON_VERSION:-3.11.3}"
 
 # ============================================================

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "zstandard>=0.20.0",
     "tabulate>=0.9.0",
     "importlib_resources>=5.0.0; python_version < '3.11'",
+    "tritonparse>=0.4.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Summary:
Add click-based command line options to the Hopper GEMM data race test script for better control over test execution:

- `--iters` / `-i`: Control the number of iterations for all tests (default: 100)
- `--tritonparse`: Enable tritonparse structured logging with optional custom output path (default: /tmp/tritonparse_logs/)

Dependency updates:
- Add tritonparse>=0.4.0 to pyproject.toml since the test script now optionally uses it for structured logging
- Update nvbit version from 1.7.6 to 1.7.7.1 in install_third_party.sh

This makes it easier to run quick validation tests with fewer iterations or enable detailed logging when debugging data race issues.

Authored with Claude.

Differential Revision: D92529442


