### PR TITLE
Refactor capture_cpu_callstack into backtrace-specific function (#202)

### DIFF
--- a/python/tests/test_formatters.py
+++ b/python/tests/test_formatters.py
@@ -51,7 +51,7 @@ class TestFormatValue(unittest.TestCase):
     def test_format_value_dict(self):
         """Test dict returns JSON string."""
         result = format_value({"a": 1})
-        self.assertEqual(result, '{"a": 1}')
+        self.assertEqual(result, '{"a":1}')
 
 
 class TestGetDisplayFields(unittest.TestCase):

--- a/src/cutracer.cu
+++ b/src/cutracer.cu
@@ -114,7 +114,8 @@ static bool generate_random_delay_enabled() {
  * @param skip Number of leading frames to skip
  * @return Vector of frame description strings
  */
-static std::vector<std::string> capture_cpu_callstack(int max_frames = 64, int skip = 2) {
+__attribute__((noinline)) static std::vector<std::string> capture_cpu_callstack_backtrace(int max_frames = 64,
+                                                                                          int skip = 2) {
   std::vector<std::string> result;
   std::vector<void*> buffer(max_frames);
 
@@ -161,6 +162,23 @@ static std::vector<std::string> capture_cpu_callstack(int max_frames = 64, int s
   }
 
   return result;
+}
+
+/**
+ * @brief Entry point for CPU call stack capture.
+ *
+ * Currently delegates to backtrace-based implementation.
+ * Future diffs will add PyTorch CapturedTraceback as a preferred path
+ * with automatic fallback to backtrace.
+ *
+ * Uses skip=3 to account for the extra wrapper frame introduced by this
+ * function, so the output starts from the caller's caller (the NVBit
+ * callback), matching the original behavior before the refactor.
+ * Frames skipped: capture_cpu_callstack_backtrace, capture_cpu_callstack,
+ * enter_kernel_launch (or nvbit_at_graph_node_launch).
+ */
+__attribute__((noinline)) static std::vector<std::string> capture_cpu_callstack() {
+  return capture_cpu_callstack_backtrace(64, 3);
 }
 
 // Global mapping tables for kernel launch tracking


### PR DESCRIPTION
Summary:

Extract the existing `capture_cpu_callstack()` implementation into
`capture_cpu_callstack_backtrace()` and add a thin entry point function
that delegates to it. This is a pure refactor with no behavior change,
preparing for a follow-up diff that adds PyTorch CapturedTraceback as
an alternative call stack capture mechanism.

Reviewed By: wlei-llvm

Differential Revision: D97564719
