### PR TITLE
Flush log files before SIGTERM to prevent log truncation (#206)

### DIFF
--- a/include/env_config.h
+++ b/include/env_config.h
@@ -135,9 +135,10 @@ extern std::string output_dir;
 
 // CPU call stack capture mode at kernel launch
 // Set via CUTRACER_CPU_CALLSTACK environment variable
-// Values: auto (default), pytorch, backtrace, 0 (disabled), 1 (=auto, backward compat)
+// Values: auto (default), auto_gil, pytorch, backtrace, 0 (disabled), 1 (=auto, backward compat)
 enum class CpuCallstackMode {
   AUTO,       // Prefer PyTorch CapturedTraceback, fallback to backtrace()
+  AUTO_GIL,   // Like AUTO, but acquires GIL if not held (for Triton launchers)
   PYTORCH,    // Force PyTorch only (empty if unavailable)
   BACKTRACE,  // Force backtrace() only (original behavior)
   DISABLED    // No call stack capture

--- a/include/env_config.h
+++ b/include/env_config.h
@@ -144,6 +144,18 @@ enum class CpuCallstackMode {
 };
 extern CpuCallstackMode cpu_callstack_mode;
 
+// Kernel events recording mode
+// Set via CUTRACER_KERNEL_EVENTS environment variable
+// Records structured kernel launch events (with optional Python callstack) to a
+// separate NDJSON file. Callstacks can be deduplicated to minimize file size.
+enum class KernelEventsMode {
+  DISABLED,  // No kernel events file (default)
+  DEDUP,     // Record events with deduplicated callstacks
+  FULL,      // Record events with full callstack per launch
+  NOSTACK,   // Record events without callstacks (metadata only)
+};
+extern KernelEventsMode kernel_events_mode;
+
 // GPU channel buffer size for GPU→CPU communication (in bytes)
 // Computed from CUTRACER_CHANNEL_RECORDS (number of records the buffer can hold)
 // or defaults to 4MB if not set. Smaller values force more frequent flushes,

--- a/include/python_callstack.h
+++ b/include/python_callstack.h
@@ -23,3 +23,25 @@
  * This function has zero compile-time dependencies on Python or PyTorch.
  */
 std::vector<std::string> capture_cpu_callstack_pytorch();
+
+/**
+ * @brief Capture the Python call stack, acquiring the GIL if necessary.
+ *
+ * Like capture_cpu_callstack_pytorch(), but when the current thread does
+ * not hold the GIL (e.g., Triton kernel launchers release it via
+ * Py_BEGIN_ALLOW_THREADS before cuLaunchKernelEx), this function
+ * temporarily acquires the GIL via PyGILState_Ensure() and inspects the
+ * current thread's CPython frame chain directly.
+ *
+ * This is safe when:
+ * - The current thread previously held the GIL and released it
+ *   (PyThreadState and frame chain are preserved)
+ * - No other thread holds the GIL while waiting for this thread
+ *
+ * Returns an empty vector if:
+ * - Python interpreter is not loaded in the process
+ * - PyGILState_Ensure/Release symbols are not available
+ * - Required CPython frame-inspection symbols are not available
+ * - Any error occurs during the Python API calls
+ */
+std::vector<std::string> capture_cpu_callstack_pytorch_acquire_gil();

--- a/python/cutracer/runner.py
+++ b/python/cutracer/runner.py
@@ -285,9 +285,10 @@ _CUTRACER_OPTIONS = [
     ),
     click.option(
         "--cpu-callstack",
-        type=click.Choice(["auto", "pytorch", "backtrace", "0", "1"]),
+        type=click.Choice(["auto", "auto_gil", "pytorch", "backtrace", "0", "1"]),
         default=None,
-        help="CPU call stack mode: auto (default), pytorch, backtrace, 0=disabled",
+        help="CPU call stack mode: auto (default), auto_gil (acquire GIL for Triton), "
+        "pytorch, backtrace, 0=disabled",
     ),
     click.option(
         "--channel-records",

--- a/python/cutracer/runner.py
+++ b/python/cutracer/runner.py
@@ -100,6 +100,7 @@ def _build_cutracer_env(
     delay_load_path: Optional[str] = None,
     cpu_callstack: Optional[str] = None,
     channel_records: Optional[int] = None,
+    kernel_events: Optional[str] = None,
     dump_cubin: bool = False,
     trace_size_limit_mb: int = 0,
     kernel_timeout_s: int = 0,
@@ -140,6 +141,8 @@ def _build_cutracer_env(
         env["CUTRACER_CPU_CALLSTACK"] = str(cpu_callstack)
     if channel_records is not None:
         env["CUTRACER_CHANNEL_RECORDS"] = str(channel_records)
+    if kernel_events is not None:
+        env["CUTRACER_KERNEL_EVENTS"] = kernel_events
     if dump_cubin:
         env["CUTRACER_DUMP_CUBIN"] = "1"
     env["CUTRACER_TRACE_SIZE_LIMIT_MB"] = str(trace_size_limit_mb)
@@ -181,6 +184,7 @@ def _print_config_summary(env: dict) -> None:
         "CUTRACER_DELAY_LOAD_PATH",
         "CUTRACER_CPU_CALLSTACK",
         "CUTRACER_CHANNEL_RECORDS",
+        "CUTRACER_KERNEL_EVENTS",
         "CUTRACER_TRACE_SIZE_LIMIT_MB",
         "CUTRACER_KERNEL_TIMEOUT_S",
         "CUTRACER_NO_DATA_TIMEOUT_S",
@@ -293,6 +297,13 @@ _CUTRACER_OPTIONS = [
         "Set to 1 for per-record flush (useful for hang debugging)",
     ),
     click.option(
+        "--kernel-events",
+        type=click.Choice(["0", "dedup", "full", "nostack"]),
+        default=None,
+        help="Kernel events recording: 0=disabled (default), dedup=callstack dedup, "
+        "full=full callstack per launch, nostack=metadata only",
+    ),
+    click.option(
         "--dump-cubin/--no-dump-cubin",
         default=None,
         help="Dump cubin files for instrumented kernels (for SASS disassembly via nvdisasm). "
@@ -359,6 +370,7 @@ def trace_command(
     delay_load_path: Optional[str],
     cpu_callstack: Optional[str],
     channel_records: Optional[int],
+    kernel_events: Optional[str],
     dump_cubin: Optional[bool],
     trace_size_limit_mb: int,
     kernel_timeout_s: int,
@@ -412,6 +424,7 @@ def trace_command(
         delay_load_path=delay_load_path,
         cpu_callstack=cpu_callstack,
         channel_records=channel_records,
+        kernel_events=kernel_events,
         dump_cubin=dump_cubin,
         trace_size_limit_mb=trace_size_limit_mb,
         kernel_timeout_s=kernel_timeout_s,

--- a/src/analysis.cu
+++ b/src/analysis.cu
@@ -984,6 +984,7 @@ static void check_kernel_hang(CTXstate* ctx_state, uint64_t current_kernel_launc
       if (ctx_state->deadlock_consecutive_hits >= 3) {
         loprintf("Deadlock sustained for %d checks; sending SIGTERM.\n", ctx_state->deadlock_consecutive_hits);
         ctx_state->deadlock_termination_initiated = true;
+        flush_log_files();
         fflush(stdout);
         fflush(stderr);
         raise(SIGTERM);
@@ -1021,6 +1022,7 @@ static void check_kernel_timeout(CTXstate* ctx_state, uint64_t current_kernel_la
       print_warp_status_summary(ctx_state, current_kernel_launch_id);
     }
     ctx_state->deadlock_termination_initiated = true;
+    flush_log_files();
     fflush(stdout);
     fflush(stderr);
     raise(SIGTERM);
@@ -1078,6 +1080,7 @@ static void check_no_data_timeout(CTXstate* ctx_state, uint64_t current_kernel_l
       print_warp_status_summary(ctx_state, current_kernel_launch_id);
     }
     ctx_state->deadlock_termination_initiated = true;
+    flush_log_files();
     fflush(stdout);
     fflush(stderr);
     raise(SIGTERM);

--- a/src/cutracer.cu
+++ b/src/cutracer.cu
@@ -82,6 +82,12 @@ bool skip_callback_flag = false;
 /* The kernel launch is identified by a global id */
 uint64_t global_kernel_launch_id = 0;
 
+/* Kernel events writer for structured launch event recording */
+static TraceWriter* g_kernel_events_writer = nullptr;
+
+/* Callstack dedup table: FNV-1a hash → already emitted */
+static std::unordered_map<uint64_t, bool> callstack_seen;
+
 /* Random number generator for delay injection on/off control.
  * Uses std::random_device to seed std::mt19937 for true randomness
  * across different runs/processes. */
@@ -207,6 +213,93 @@ __attribute__((noinline)) static std::pair<std::vector<std::string>, std::string
   }
   // Unreachable for known enum values; fallback defensively for future additions
   return {capture_cpu_callstack_backtrace(64, 3), "backtrace"};
+}
+
+/**
+ * @brief Compute FNV-1a hash of a callstack (vector of frame strings).
+ *
+ * Uses the same FNV-1a constants as compute_kernel_checksum().
+ * Includes an inter-frame separator byte (0xFF) to prevent collisions
+ * between e.g. {"a","bc"} and {"ab","c"}.
+ */
+static uint64_t hash_callstack(const std::vector<std::string>& frames) {
+  const uint64_t FNV_OFFSET = 14695981039346656037ULL;
+  const uint64_t FNV_PRIME = 1099511628211ULL;
+  uint64_t hash = FNV_OFFSET;
+  for (const auto& frame : frames) {
+    for (char c : frame) {
+      hash ^= static_cast<uint64_t>(c);
+      hash *= FNV_PRIME;
+    }
+    hash ^= 0xFF;
+    hash *= FNV_PRIME;
+  }
+  return hash;
+}
+
+/**
+ * @brief Write a kernel launch event to the kernel events file.
+ *
+ * In DEDUP mode, emits a callstack_def record on first occurrence and
+ * references it by callstack_id in subsequent launch events.
+ * In FULL mode, inlines the complete callstack in every launch event.
+ * In NOSTACK mode, omits callstack information entirely.
+ */
+static void write_kernel_launch_event(const KernelFuncMetadata& meta, const KernelDimensions& dims,
+                                      unsigned int dynamic_shmem, uint64_t stream_id, uint64_t launch_id,
+                                      const std::vector<std::string>& callstack, const std::string& callstack_source) {
+  if (!g_kernel_events_writer || kernel_events_mode == KernelEventsMode::DISABLED) {
+    return;
+  }
+
+  nlohmann::json event;
+  event["type"] = "kernel_launch";
+  event["kernel_launch_id"] = launch_id;
+  event["kernel_name"] = meta.unmangled_name;
+  event["kernel_checksum"] = meta.kernel_checksum;
+  event["grid"] = {dims.gridDimX, dims.gridDimY, dims.gridDimZ};
+  event["block"] = {dims.blockDimX, dims.blockDimY, dims.blockDimZ};
+  event["nregs"] = meta.nregs;
+  event["shmem"] = meta.shmem_static_nbytes + dynamic_shmem;
+  event["stream_id"] = stream_id;
+
+  if (kernel_events_mode == KernelEventsMode::DEDUP) {
+    if (callstack.empty()) {
+      event["callstack_id"] = nullptr;
+    } else {
+      uint64_t cs_hash = hash_callstack(callstack);
+      std::ostringstream oss;
+      oss << std::hex << cs_hash;
+      std::string callstack_id = oss.str();
+      event["callstack_id"] = callstack_id;
+
+      if (callstack_seen.emplace(cs_hash, true).second) {
+        nlohmann::json def;
+        def["type"] = "callstack_def";
+        def["callstack_id"] = callstack_id;
+        def["frames"] = callstack;
+        if (!callstack_source.empty()) {
+          def["source"] = callstack_source;
+        }
+        g_kernel_events_writer->write_metadata(def);
+      }
+    }
+  } else if (kernel_events_mode == KernelEventsMode::FULL) {
+    if (!callstack.empty()) {
+      event["cpu_callstack"] = callstack;
+      if (!callstack_source.empty()) {
+        event["cpu_callstack_source"] = callstack_source;
+      }
+    }
+  }
+  // NOSTACK mode: no callstack fields added
+
+  g_kernel_events_writer->write_metadata(event);
+
+  // Flush immediately — kernel events writer only uses write_metadata() (not
+  // write_trace()), so the internal json_buffer_ would never reach the flush
+  // threshold and data would stay in memory until process exit.
+  g_kernel_events_writer->flush();
 }
 
 // Global mapping tables for kernel launch tracking
@@ -845,6 +938,18 @@ static bool enter_kernel_launch(CUcontext ctx, CUfunction func, uint64_t& kernel
     }
     kernel_launch_to_dimensions_map[kernel_launch_id] = dims;
 
+    // Write structured kernel launch event (applies to ALL kernels, not just instrumented)
+    if (kernel_events_mode != KernelEventsMode::DISABLED) {
+      uint64_t stream_id = 0;
+      if (cbid == API_CUDA_cuLaunchKernelEx_ptsz || cbid == API_CUDA_cuLaunchKernelEx) {
+        stream_id = (uint64_t)((cuLaunchKernelEx_params*)params)->config->hStream;
+      } else {
+        stream_id = (uint64_t)((cuLaunchKernel_params*)params)->hStream;
+      }
+      write_kernel_launch_event(meta, dims, dynamic_shmem, stream_id, kernel_launch_id, cpu_callstack,
+                                callstack_source);
+    }
+
     // increment kernel launch id for next launch
     // kernel id can be changed here, since nvbit_set_at_launch() has copied
     // its value above.
@@ -1126,6 +1231,14 @@ void nvbit_at_ctx_term(CUcontext ctx) {
 
   cleanup_log_handle();
 
+  // Cleanup kernel events writer (only once, guard with nullptr check)
+  if (g_kernel_events_writer) {
+    g_kernel_events_writer->flush();
+    delete g_kernel_events_writer;
+    g_kernel_events_writer = nullptr;
+    callstack_seen.clear();
+  }
+
   // Finalize delay configuration (saves to JSON if path is set)
   finalize_delay_config();
 }
@@ -1164,6 +1277,13 @@ void nvbit_at_graph_node_launch(CUcontext ctx, CUfunction func, CUstream stream,
 
   // Capture the CPU call stack for graph node launches as well
   auto [cpu_callstack, callstack_source] = capture_cpu_callstack();
+
+  // Write structured kernel launch event for graph node launches
+  if (kernel_events_mode != KernelEventsMode::DISABLED) {
+    const auto& meta_ev = get_or_create_kernel_func_metadata(func, ctx);
+    write_kernel_launch_event(meta_ev, dims, config.shmem_dynamic_nbytes, (uint64_t)stream, global_kernel_launch_id,
+                              cpu_callstack, callstack_source);
+  }
 
   // Create TraceWriter for this graph node launch only if instrumentation is enabled
   // Otherwise, trace files would be empty (no data to write)
@@ -1205,4 +1325,27 @@ void nvbit_at_init() {
   pthread_mutex_init(&mutex, &attr);
 
   pthread_mutex_init(&cuda_event_mutex, &attr);
+
+  // Create kernel events writer if enabled
+  if (kernel_events_mode != KernelEventsMode::DISABLED) {
+    // Generate timestamped filename in output_dir
+    char time_buf[32];
+    time_t now = time(nullptr);
+    struct tm tm_info;
+    localtime_r(&now, &tm_info);
+    strftime(time_buf, sizeof(time_buf), "%Y%m%d_%H%M%S", &tm_info);
+
+    std::string events_basename;
+    if (!output_dir.empty()) {
+      events_basename = output_dir + (output_dir.back() != '/' ? "/" : "") + "cutracer_kernel_events_" + time_buf;
+    } else {
+      events_basename = std::string("cutracer_kernel_events_") + time_buf;
+    }
+    g_kernel_events_writer = new TraceWriter(events_basename, trace_format);
+    loprintf("Kernel events writer created: %s (mode: %s)\n", events_basename.c_str(),
+             kernel_events_mode == KernelEventsMode::DEDUP     ? "dedup"
+             : kernel_events_mode == KernelEventsMode::FULL    ? "full"
+             : kernel_events_mode == KernelEventsMode::NOSTACK ? "nostack"
+                                                               : "unknown");
+  }
 }

--- a/src/cutracer.cu
+++ b/src/cutracer.cu
@@ -210,6 +210,13 @@ __attribute__((noinline)) static std::pair<std::vector<std::string>, std::string
       }
       return {capture_cpu_callstack_backtrace(64, 3), "backtrace"};
     }
+    case CpuCallstackMode::AUTO_GIL: {
+      auto result = capture_cpu_callstack_pytorch_acquire_gil();
+      if (!result.empty()) {
+        return {std::move(result), "cpython_gil"};
+      }
+      return {capture_cpu_callstack_backtrace(64, 3), "backtrace"};
+    }
   }
   // Unreachable for known enum values; fallback defensively for future additions
   return {capture_cpu_callstack_backtrace(64, 3), "backtrace"};

--- a/src/cutracer.cu
+++ b/src/cutracer.cu
@@ -275,6 +275,25 @@ static std::string compute_kernel_checksum(const std::string& kernel_name, const
 }
 
 /**
+ * @brief Ensure kernel_checksum is populated for the given metadata.
+ *
+ * Idempotent: if checksum is already computed, this is a no-op.
+ * Also ensures mangled_name is set (needed for checksum computation).
+ *
+ * @param meta The kernel metadata entry to populate
+ * @param ctx The CUDA context
+ * @param func The CUfunction handle
+ */
+static void ensure_kernel_checksum(KernelFuncMetadata& meta, CUcontext ctx, CUfunction func) {
+  if (!meta.kernel_checksum.empty()) return;
+  if (meta.mangled_name.empty()) {
+    meta.mangled_name = nvbit_get_func_name(ctx, func, true);
+  }
+  const std::vector<Instr*>& instrs = nvbit_get_instrs(ctx, func);
+  meta.kernel_checksum = compute_kernel_checksum(meta.mangled_name, instrs);
+}
+
+/**
  * @brief Check if an instruction should be instrumented based on category filtering.
  *
  * When category filtering is enabled (CUTRACER_INSTR_CATEGORIES is set),
@@ -312,8 +331,9 @@ static bool should_instrument_instr_by_category(Instr* instr) {
  * @brief Get or create per-function metadata entry.
  *
  * If the function is seen for the first time, inserts a new entry and
- * populates lightweight fields (name, func_addr, nregs, shmem) via
- * CUDA driver API.  Subsequent calls return the existing entry directly.
+ * populates all fields (name, func_addr, nregs, shmem, checksum) via
+ * CUDA driver API and NVBit.  Subsequent calls return the existing entry
+ * directly.
  */
 static KernelFuncMetadata& get_or_create_kernel_func_metadata(CUfunction func, CUcontext ctx) {
   auto [it, inserted] = kernel_metadata_by_func.emplace(func, KernelFuncMetadata{});
@@ -322,6 +342,7 @@ static KernelFuncMetadata& get_or_create_kernel_func_metadata(CUfunction func, C
     it->second.func_addr = nvbit_get_func_addr(ctx, func);
     CUDA_SAFECALL(cuFuncGetAttribute(&it->second.nregs, CU_FUNC_ATTRIBUTE_NUM_REGS, func));
     CUDA_SAFECALL(cuFuncGetAttribute(&it->second.shmem_static_nbytes, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, func));
+    ensure_kernel_checksum(it->second, ctx, func);
   }
   return it->second;
 }
@@ -394,11 +415,9 @@ bool instrument_function_if_needed(CUcontext ctx, CUfunction func) {
     const std::vector<Instr*>& instrs = nvbit_get_instrs(ctx, f);
     loprintf_v("Inspecting kernel %s at address 0x%lx\n", nvbit_get_func_name(ctx, f), nvbit_get_func_addr(ctx, f));
 
-    // Get or create per-function metadata (basic fields filled by helper)
+    // Get or create per-function metadata (checksum already computed by helper)
     auto& meta = get_or_create_kernel_func_metadata(f, ctx);
-    meta.mangled_name = mangled_name;
-    meta.kernel_checksum = compute_kernel_checksum(mangled_name, instrs);
-    loprintf_v("Computed kernel checksum for %s: %s\n", mangled_name, meta.kernel_checksum.c_str());
+    loprintf_v("Kernel checksum for %s: %s\n", meta.mangled_name.c_str(), meta.kernel_checksum.c_str());
 
     if (dump_cubin) {
       // Use the same "kernel_{checksum}_{name}" prefix as trace files

--- a/src/env_config.cu
+++ b/src/env_config.cu
@@ -70,6 +70,9 @@ std::string output_dir;
 // CPU call stack capture mode at kernel launch (default: AUTO)
 CpuCallstackMode cpu_callstack_mode;
 
+// Kernel events recording mode (default: DISABLED)
+KernelEventsMode kernel_events_mode;
+
 // GPU channel buffer size (in bytes), computed from CUTRACER_CHANNEL_RECORDS
 // Default: 4MB (1 << 22)
 int channel_buffer_size;
@@ -862,6 +865,35 @@ void init_config_from_env() {
   } else {
     printf("WARNING: Invalid CUTRACER_CPU_CALLSTACK='%s'. Using 'auto'.\n", cpu_callstack_str.c_str());
     cpu_callstack_mode = CpuCallstackMode::AUTO;
+  }
+
+  // Kernel events recording mode (default: disabled)
+  // Records structured kernel launch events with optional callstack to a separate NDJSON file
+  std::string kernel_events_str;
+  get_var_str(kernel_events_str, "CUTRACER_KERNEL_EVENTS", "0",
+              "Kernel events mode (0=disabled, dedup=callstack dedup, full=full callstack, nostack=metadata only)");
+  if (kernel_events_str == "0" || kernel_events_str.empty()) {
+    kernel_events_mode = KernelEventsMode::DISABLED;
+  } else if (kernel_events_str == "dedup" || kernel_events_str == "1") {
+    kernel_events_mode = KernelEventsMode::DEDUP;
+  } else if (kernel_events_str == "full") {
+    kernel_events_mode = KernelEventsMode::FULL;
+  } else if (kernel_events_str == "nostack") {
+    kernel_events_mode = KernelEventsMode::NOSTACK;
+  } else {
+    loprintf("WARNING: Invalid CUTRACER_KERNEL_EVENTS='%s'. Using '0' (disabled).\n", kernel_events_str.c_str());
+    kernel_events_mode = KernelEventsMode::DISABLED;
+  }
+
+  // Cross-validate: callstack capture must be enabled for dedup/full modes
+  if ((kernel_events_mode == KernelEventsMode::DEDUP || kernel_events_mode == KernelEventsMode::FULL) &&
+      cpu_callstack_mode == CpuCallstackMode::DISABLED) {
+    loprintf(
+        "WARNING: CUTRACER_KERNEL_EVENTS=%s requires callstack capture, "
+        "but CUTRACER_CPU_CALLSTACK=0 (disabled).\n"
+        "Launch events will have null callstack_id. Consider using 'nostack' mode "
+        "or enabling cpu_callstack.\n",
+        kernel_events_str.c_str());
   }
 
   // Channel buffer size configuration

--- a/src/env_config.cu
+++ b/src/env_config.cu
@@ -853,9 +853,12 @@ void init_config_from_env() {
   // CPU call stack capture mode (default: auto)
   // Supports: auto, pytorch, backtrace, 0 (disabled), 1 (=auto, backward compat)
   std::string cpu_callstack_str;
-  get_var_str(cpu_callstack_str, "CUTRACER_CPU_CALLSTACK", "auto", "CPU call stack mode (auto|pytorch|backtrace|0|1)");
+  get_var_str(cpu_callstack_str, "CUTRACER_CPU_CALLSTACK", "auto",
+              "CPU call stack mode (auto|auto_gil|pytorch|backtrace|0|1)");
   if (cpu_callstack_str == "auto" || cpu_callstack_str == "1") {
     cpu_callstack_mode = CpuCallstackMode::AUTO;
+  } else if (cpu_callstack_str == "auto_gil") {
+    cpu_callstack_mode = CpuCallstackMode::AUTO_GIL;
   } else if (cpu_callstack_str == "pytorch") {
     cpu_callstack_mode = CpuCallstackMode::PYTORCH;
   } else if (cpu_callstack_str == "backtrace") {

--- a/src/python_callstack.cpp
+++ b/src/python_callstack.cpp
@@ -2,10 +2,11 @@
  * SPDX-FileCopyrightText: Copyright (c) Meta Platforms, Inc. and affiliates.
  * SPDX-License-Identifier: MIT
  *
- * Dynamically calls PyTorch's CapturedTraceback Python API to capture
- * the Python call stack at CUDA kernel launch time. Uses dlsym to resolve
- * Python C API functions at runtime — no compile-time dependency on
- * Python.h or libpython.
+ * Captures Python call stacks at CUDA kernel launch time. The standard
+ * path uses PyTorch's CapturedTraceback API; auto_gil uses lower-level
+ * CPython frame introspection after reacquiring the GIL. Uses dlsym to
+ * resolve Python C API functions at runtime — no compile-time dependency
+ * on Python.h or libpython.
  *
  * This is the same approach used by tritonparse (structured_logging.py),
  * adapted for C++ via the Python C API.
@@ -16,6 +17,7 @@
 #include <dlfcn.h>
 #include <sys/types.h>
 
+#include <algorithm>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -24,6 +26,7 @@
 // Python C API types — defined locally to avoid requiring Python.h
 using PyObject = void;
 using Py_ssize_t = ssize_t;
+using PyThreadState = void;
 
 // ---------------------------------------------------------------------------
 // Python C API function pointers (resolved lazily via dlsym)
@@ -44,6 +47,15 @@ static void (*p_Py_DecRef)(PyObject*) = nullptr;
 static void (*p_Py_IncRef)(PyObject*) = nullptr;
 static PyObject* (*p_PyErr_Occurred)() = nullptr;
 static void (*p_PyErr_Clear)() = nullptr;
+static PyThreadState* (*p_PyGILState_GetThisThreadState)() = nullptr;
+static PyObject* (*p_PyThreadState_GetFrame)(PyThreadState*) = nullptr;
+static PyObject* (*p_PyFrame_GetBack)(PyObject*) = nullptr;
+static int (*p_PyFrame_GetLineNumber)(PyObject*) = nullptr;
+
+// GIL acquisition/release for threads that released the GIL (e.g., Triton launcher)
+// PyGILState_STATE is an int enum in CPython: PyGILState_LOCKED=0, PyGILState_UNLOCKED=1
+static int (*p_PyGILState_Ensure)() = nullptr;
+static void (*p_PyGILState_Release)(int) = nullptr;
 
 // Tri-state resolution: allows retry if Python is not yet loaded
 enum class PythonApiState {
@@ -100,6 +112,12 @@ static bool resolve_python_api() {
   decltype(p_Py_IncRef) r_Py_IncRef = nullptr;
   decltype(p_PyErr_Occurred) r_PyErr_Occurred = nullptr;
   decltype(p_PyErr_Clear) r_PyErr_Clear = nullptr;
+  decltype(p_PyGILState_GetThisThreadState) r_PyGILState_GetThisThreadState = nullptr;
+  decltype(p_PyThreadState_GetFrame) r_PyThreadState_GetFrame = nullptr;
+  decltype(p_PyFrame_GetBack) r_PyFrame_GetBack = nullptr;
+  decltype(p_PyFrame_GetLineNumber) r_PyFrame_GetLineNumber = nullptr;
+  decltype(p_PyGILState_Ensure) r_PyGILState_Ensure = nullptr;
+  decltype(p_PyGILState_Release) r_PyGILState_Release = nullptr;
 
 #define RESOLVE(name)                                         \
   r_##name = (decltype(r_##name))dlsym(handle, #name);        \
@@ -127,6 +145,17 @@ static bool resolve_python_api() {
 
 #undef RESOLVE
 
+  // Optional symbols used only by auto_gil mode. These are not required for
+  // the standard pytorch/CapturedTraceback path, so we resolve them
+  // separately without failing the entire resolve.
+  r_PyGILState_GetThisThreadState =
+      (decltype(r_PyGILState_GetThisThreadState))dlsym(handle, "PyGILState_GetThisThreadState");
+  r_PyThreadState_GetFrame = (decltype(r_PyThreadState_GetFrame))dlsym(handle, "PyThreadState_GetFrame");
+  r_PyFrame_GetBack = (decltype(r_PyFrame_GetBack))dlsym(handle, "PyFrame_GetBack");
+  r_PyFrame_GetLineNumber = (decltype(r_PyFrame_GetLineNumber))dlsym(handle, "PyFrame_GetLineNumber");
+  r_PyGILState_Ensure = (decltype(r_PyGILState_Ensure))dlsym(handle, "PyGILState_Ensure");
+  r_PyGILState_Release = (decltype(r_PyGILState_Release))dlsym(handle, "PyGILState_Release");
+
   dlclose(handle);
 
   // Publish all resolved pointers atomically
@@ -145,6 +174,12 @@ static bool resolve_python_api() {
   p_Py_IncRef = r_Py_IncRef;
   p_PyErr_Occurred = r_PyErr_Occurred;
   p_PyErr_Clear = r_PyErr_Clear;
+  p_PyGILState_GetThisThreadState = r_PyGILState_GetThisThreadState;
+  p_PyThreadState_GetFrame = r_PyThreadState_GetFrame;
+  p_PyFrame_GetBack = r_PyFrame_GetBack;
+  p_PyFrame_GetLineNumber = r_PyFrame_GetLineNumber;
+  p_PyGILState_Ensure = r_PyGILState_Ensure;
+  p_PyGILState_Release = r_PyGILState_Release;
 
   python_api_state = PythonApiState::RESOLVED;
   return true;
@@ -239,6 +274,67 @@ static PyObject* get_captured_traceback_cls() {
   // Cache with an owned reference (prevent GC from collecting it)
   cached_captured_traceback_cls = cls.release();
   return cached_captured_traceback_cls;
+}
+
+/**
+ * @brief Capture the current thread's Python frames using only CPython C APIs.
+ *
+ * Unlike CapturedTraceback.extract(), this does not import modules or execute
+ * Python code while inside the NVBit callback. That makes it suitable for
+ * auto_gil mode, where we want Python-level call stacks without the side
+ * effects of running higher-level traceback helpers during launch.
+ *
+ * The caller must already hold the GIL.
+ */
+static std::vector<std::string> capture_cpu_callstack_cpython_frames() {
+  std::vector<std::string> result;
+
+  if (!p_PyGILState_GetThisThreadState || !p_PyThreadState_GetFrame || !p_PyFrame_GetBack || !p_PyFrame_GetLineNumber) {
+    return result;
+  }
+
+  PyThreadState* tstate = p_PyGILState_GetThisThreadState();
+  if (!tstate) {
+    return result;
+  }
+
+  PyRef frame(p_PyThreadState_GetFrame(tstate));
+  if (!frame) {
+    if (p_PyErr_Occurred()) {
+      p_PyErr_Clear();
+    }
+    return result;
+  }
+
+  result.reserve(32);
+  while (frame) {
+    PyRef code_obj(p_PyObject_GetAttrString(frame, "f_code"));
+    PyRef py_filename(code_obj ? p_PyObject_GetAttrString(code_obj, "co_filename") : nullptr);
+    PyRef py_name(code_obj ? p_PyObject_GetAttrString(code_obj, "co_name") : nullptr);
+
+    const char* filename = py_filename ? p_PyUnicode_AsUTF8(py_filename) : nullptr;
+    const char* funcname = py_name ? p_PyUnicode_AsUTF8(py_name) : nullptr;
+    int lineno = p_PyFrame_GetLineNumber(frame);
+
+    if (p_PyErr_Occurred()) {
+      p_PyErr_Clear();
+      if (lineno < 0) {
+        lineno = 0;
+      }
+    }
+
+    result.push_back(std::string(filename ? filename : "??") + ":" + std::to_string(lineno) + " in " +
+                     std::string(funcname ? funcname : "??"));
+
+    PyRef next_frame(p_PyFrame_GetBack(frame));
+    if (p_PyErr_Occurred()) {
+      p_PyErr_Clear();
+    }
+    frame = std::move(next_frame);
+  }
+
+  std::reverse(result.begin(), result.end());
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -357,6 +453,53 @@ std::vector<std::string> capture_cpu_callstack_pytorch() {
   if (p_PyErr_Occurred()) {
     p_PyErr_Clear();
   }
+
+  return result;
+}
+
+std::vector<std::string> capture_cpu_callstack_pytorch_acquire_gil() {
+  // Reentrancy guard (shared with capture_cpu_callstack_pytorch)
+  static thread_local bool capturing_gil = false;
+  if (capturing_gil) {
+    return {};
+  }
+  capturing_gil = true;
+
+  std::vector<std::string> result;
+
+  auto reset_guard = [](bool* flag) { *flag = false; };
+  std::unique_ptr<bool, decltype(reset_guard)> guard(&capturing_gil, reset_guard);
+
+  if (!resolve_python_api()) {
+    return result;
+  }
+  if (!p_Py_IsInitialized()) {
+    return result;
+  }
+
+  bool already_holds_gil = p_PyGILState_Check();
+  if (already_holds_gil) {
+    return capture_cpu_callstack_cpython_frames();
+  }
+
+  // GIL not held — acquire it temporarily.
+  // This is safe when the current thread released the GIL via
+  // Py_BEGIN_ALLOW_THREADS (e.g., Triton launcher before cuLaunchKernelEx).
+  // The thread's PyThreadState and frame chain are preserved and frozen
+  // at the point of GIL release — exactly the callstack we want.
+  if (!p_PyGILState_Ensure || !p_PyGILState_Release) {
+    return result;
+  }
+
+  int saved_state = p_PyGILState_Ensure();
+  result = capture_cpu_callstack_cpython_frames();
+
+  if (p_PyErr_Occurred()) {
+    p_PyErr_Clear();
+  }
+
+  // Release the GIL back to the state before we acquired it
+  p_PyGILState_Release(saved_state);
 
   return result;
 }


### PR DESCRIPTION
Summary:

When CUTracer detects a deadlock, kernel timeout, or no-data hang, it
sends SIGTERM to terminate the process. The main log file uses C stdio
buffered I/O (FILE*), and SIGTERM kills the process without flushing
these buffers — causing the last ~8KB of log data to be lost.

The fix adds flush_log_files() before raise(SIGTERM) in all three
termination paths:
1. Deadlock detection (sustained loop detection)
2. Kernel timeout (CUTRACER_KERNEL_TIMEOUT_S)
3. No-data timeout (CUTRACER_NO_DATA_TIMEOUT_S)

stdout/stderr were already flushed (fflush), but the main log file
(g_main_log_file) was not. flush_log_files() already exists and is
called periodically by recv_thread — this just ensures it also runs
on the critical path before process termination.

Authored with AI (Claude).

Reviewed By: wlei-llvm

Differential Revision: D100854067
