### PR TITLE
Add cluster-level random delay mode for inter-CTA sync testing (#207)

### DIFF
--- a/include/delay_inject_config.h
+++ b/include/delay_inject_config.h
@@ -28,6 +28,7 @@ struct DelayInstrumentationPoint {
   std::string sass;
   uint32_t delay_ns;
   bool enabled;
+  uint32_t cluster_seed;  // Seed for cluster mode CTA selection (0 when not in cluster mode)
 };
 
 /**
@@ -86,7 +87,8 @@ KernelDelayInjectConfig* create_kernel_delay_config(const std::string& kernel_na
  * @param delay_ns The delay value in nanoseconds
  * @param enabled Whether this point is enabled
  */
-void register_delay_instrumentation_point(KernelDelayInjectConfig* kdc, Instr* instr, uint32_t delay_ns, bool enabled);
+void register_delay_instrumentation_point(KernelDelayInjectConfig* kdc, Instr* instr, uint32_t delay_ns, bool enabled,
+                                          uint32_t cluster_seed = 0);
 
 /**
  * @brief Finalize and save delay config at context termination.
@@ -121,7 +123,7 @@ bool is_delay_replay_mode();
  * @return true if found, false if not found
  */
 bool lookup_replay_config(const std::map<uint64_t, DelayInstrumentationPoint>* replay_points, uint64_t pc_offset,
-                          bool& enabled, uint32_t& delay_ns);
+                          bool& enabled, uint32_t& delay_ns, uint32_t& cluster_seed);
 
 /**
  * @brief Get the instrumentation points map for a kernel in replay mode.

--- a/include/env_config.h
+++ b/include/env_config.h
@@ -113,12 +113,35 @@ extern uint32_t g_delay_ns;
 // which can help narrow the search space for race detection.
 extern uint32_t g_delay_min_ns;
 
-// Delay mode: controls how delays are applied per-thread (default: random)
-// 0 = fixed: all threads get the same delay (preserves relative timing, often masks races)
-// 1 = random (default): each thread gets a random delay in [min_delay_ns, delay_ns] using
-//     thread-local entropy (threadIdx, blockIdx, clock) to create
-//     asymmetric timing that better exposes data races
+// Delay distribution mode (orthogonal to CTA targeting; see g_delay_cta_target):
+// 0 = fixed: all delayed threads sleep `delay_ns` exactly (preserves relative
+//     timing, often masks races)
+// 1 = random (default): each delayed thread sleeps a random duration in
+//     [min_delay_ns, delay_ns] using thread-local entropy (threadIdx, blockIdx,
+//     clock) to create asymmetric timing that better exposes data races
 extern int g_delay_mode;
+
+// CTA targeting mode (orthogonal to delay distribution; see g_delay_mode):
+// 0 = all (default): every CTA's threads receive the delay
+// 1 = one_per_cluster: only one CTA per cluster (selected via cluster_seed or
+//     g_cluster_cta_id) receives the delay; other CTAs in the cluster skip
+//     entirely. Exposes missing inter-CTA synchronization. Requires sm_90+ and
+//     a cluster-launched kernel; on non-cluster kernels the device function
+//     short-circuits and a host-side WARNING is emitted once per CUfunction.
+extern int g_delay_cta_target;
+
+// One-CTA-per-cluster targeting override (only meaningful when
+// g_delay_cta_target == 1).
+// -1 (default) = random per instrumentation point (uses cluster_seed % cluster_size).
+// >= 0        = force every instrumentation point to delay this CTA index in every cluster.
+// Useful for deterministic A/B bisection of inter-CTA sync issues, or systematic
+// sweeps over CTA indices instead of relying on random coverage.
+//
+// Precedence vs replay (delay_load_path): when this is set, it overrides the
+// per-point cluster_seed loaded from the replay config — i.e. setting both
+// makes the replay no longer bit-identical to the recording. A startup warning
+// is emitted in that case (see init_config_from_env).
+extern int g_cluster_cta_id;
 
 // Delay dump output path (optional)
 // If set, instrumentation points will be written to this JSON file for later replay

--- a/include/instrument.h
+++ b/include/instrument.h
@@ -112,6 +112,27 @@ void instrument_delay_injection(Instr* instr, uint32_t delay_ns);
 void instrument_random_delay_injection(Instr* instr, uint32_t min_delay_ns, uint32_t max_delay_ns);
 
 /**
+ * @brief Instruments an instruction to inject a random delay on one CTA per cluster.
+ *
+ * Inserts a call to the `instrument_delay_random_cluster` device function before
+ * the instruction. Only the CTA selected by `cluster_seed % cluster_size` receives
+ * the delay; other CTAs in the cluster skip entirely. This creates inter-CTA timing
+ * asymmetry to expose missing cluster-level synchronization.
+ *
+ * @param instr The instruction to instrument
+ * @param min_delay_ns Minimum delay in nanoseconds
+ * @param max_delay_ns Maximum delay in nanoseconds
+ * @param cluster_seed Host-generated seed for CTA selection (stored in config for replay)
+ * @param cta_id_override If >= 0, force this CTA index for every instrumentation
+ *        point (overrides cluster_seed-based random selection). -1 = random.
+ * @param use_fixed_delay 0 = per-thread random delay in [min, max] within the
+ *        selected CTA. 1 = fixed delay = max_delay_ns for all threads in the
+ *        selected CTA (cluster targeting orthogonal to delay distribution).
+ */
+void instrument_cluster_delay_injection(Instr* instr, uint32_t min_delay_ns, uint32_t max_delay_ns,
+                                        uint32_t cluster_seed, int32_t cta_id_override, int32_t use_fixed_delay);
+
+/**
  * @brief SASS instruction patterns for delay injection.
  */
 static const std::vector<const char*> DELAY_INJECTION_PATTERNS = {

--- a/python/cutracer/runner.py
+++ b/python/cutracer/runner.py
@@ -96,6 +96,7 @@ def _build_cutracer_env(
     delay_ns: Optional[int],
     delay_min_ns: Optional[int] = None,
     delay_mode: Optional[str] = None,
+    delay_cluster_cta_id: Optional[int] = None,
     delay_dump_path: Optional[str] = None,
     delay_load_path: Optional[str] = None,
     cpu_callstack: Optional[str] = None,
@@ -133,6 +134,8 @@ def _build_cutracer_env(
         env["CUTRACER_DELAY_MIN_NS"] = str(delay_min_ns)
     if delay_mode is not None:
         env["CUTRACER_DELAY_MODE"] = delay_mode
+    if delay_cluster_cta_id is not None:
+        env["CUTRACER_CLUSTER_CTA_ID"] = str(delay_cluster_cta_id)
     if delay_dump_path is not None:
         env["CUTRACER_DELAY_DUMP_PATH"] = delay_dump_path
     if delay_load_path is not None:
@@ -180,6 +183,7 @@ def _print_config_summary(env: dict) -> None:
         "CUTRACER_DELAY_NS",
         "CUTRACER_DELAY_MIN_NS",
         "CUTRACER_DELAY_MODE",
+        "CUTRACER_CLUSTER_CTA_ID",
         "CUTRACER_DELAY_DUMP_PATH",
         "CUTRACER_DELAY_LOAD_PATH",
         "CUTRACER_CPU_CALLSTACK",
@@ -268,10 +272,24 @@ _CUTRACER_OPTIONS = [
     ),
     click.option(
         "--delay-mode",
-        type=click.Choice(["random", "fixed"]),
+        type=click.Choice(["random", "fixed", "cluster", "cluster_fixed"]),
         default=None,
-        help="Delay mode: 'random' (per-thread random delay, default) or "
-        "'fixed' (same delay for all threads, often masks races)",
+        help="Delay mode (combines distribution and CTA targeting): "
+        "'random' = per-thread random delay, all CTAs (default); "
+        "'fixed' = same delay for all threads, all CTAs (often masks races); "
+        "'cluster' = per-thread random delay, one CTA per cluster (exposes inter-CTA sync issues); "
+        "'cluster_fixed' = fixed delay, one CTA per cluster (per-CTA timing skew without intra-CTA jitter).",
+    ),
+    click.option(
+        "--delay-cluster-cta-id",
+        type=int,
+        default=None,
+        help="Cluster mode only: force every instrumentation point to delay this CTA "
+        "index in every cluster (e.g. 0 = always slow CTA 0). Default: random per point. "
+        "Useful for deterministic A/B bisection of inter-CTA sync issues. "
+        "Precedence: when set together with --delay-load-path, this override wins over "
+        "the per-point cluster_seed in the replay config — replay is no longer bit-identical "
+        "to the recording. Unset (or omit) for exact replay.",
     ),
     click.option(
         "--delay-dump-path",
@@ -367,6 +385,7 @@ def trace_command(
     delay_ns: Optional[int],
     delay_min_ns: Optional[int],
     delay_mode: Optional[str],
+    delay_cluster_cta_id: Optional[int],
     delay_dump_path: Optional[str],
     delay_load_path: Optional[str],
     cpu_callstack: Optional[str],
@@ -421,6 +440,7 @@ def trace_command(
         delay_ns=delay_ns,
         delay_min_ns=delay_min_ns,
         delay_mode=delay_mode,
+        delay_cluster_cta_id=delay_cluster_cta_id,
         delay_dump_path=delay_dump_path,
         delay_load_path=delay_load_path,
         cpu_callstack=cpu_callstack,

--- a/src/cutracer.cu
+++ b/src/cutracer.cu
@@ -94,16 +94,102 @@ static std::unordered_map<uint64_t, bool> callstack_seen;
 static std::mt19937 g_delay_rng;
 static bool g_delay_rng_initialized = false;
 
-/* Generate random enabled state (50% probability) */
-static bool generate_random_delay_enabled() {
+/* Lazily initialize the RNG with true randomness */
+static void ensure_delay_rng_initialized() {
   if (!g_delay_rng_initialized) {
-    // Seed with std::random_device for true randomness each run
     std::random_device rd;
     g_delay_rng.seed(rd());
     g_delay_rng_initialized = true;
   }
+}
+
+/* Generate random enabled state (50% probability) */
+static bool generate_random_delay_enabled() {
+  ensure_delay_rng_initialized();
   std::uniform_int_distribution<int> dist(0, 1);
   return dist(g_delay_rng) == 1;
+}
+
+/* Generate a random seed for cluster mode CTA selection */
+static uint32_t generate_cluster_seed() {
+  ensure_delay_rng_initialized();
+  return g_delay_rng();
+}
+
+/**
+ * @brief Extract the cluster_dim attribute from a cuLaunchKernelEx params
+ *        struct, if present. Returns true and fills (cx, cy, cz) on hit;
+ *        returns false (and leaves outputs unchanged) if either the cbid is
+ *        not a cuLaunchKernelEx variant or the attribute is absent.
+ *
+ * Centralizes the launch-attr scan that's needed in two places: at every
+ * direct launch (so graph-node launches can later look up the dim) and at the
+ * direct-launch logging site itself.
+ */
+static bool extract_cluster_dim_from_launch_ex(nvbit_api_cuda_t cbid, void* params, unsigned int& cx, unsigned int& cy,
+                                               unsigned int& cz) {
+  if (cbid != API_CUDA_cuLaunchKernelEx_ptsz && cbid != API_CUDA_cuLaunchKernelEx) {
+    return false;
+  }
+  cuLaunchKernelEx_params* p = (cuLaunchKernelEx_params*)params;
+  for (unsigned int i = 0; i < p->config->numAttrs; ++i) {
+    if (p->config->attrs[i].id == CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION) {
+      cx = p->config->attrs[i].value.clusterDim.x;
+      cy = p->config->attrs[i].value.clusterDim.y;
+      cz = p->config->attrs[i].value.clusterDim.z;
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * @brief Log cluster dimensions for a kernel under --delay-mode cluster, once
+ *        per CUfunction.
+ *
+ * If the caller has a launch-time cluster dim (via CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION
+ * on cuLaunchKernelEx), pass it in via dyn_*; otherwise pass 0 and we fall back
+ * to the kernel-declared __cluster_dims__ via cuFuncGetAttribute. When the
+ * resulting cluster size is <= 1 we emit a WARNING because cluster mode is a
+ * no-op for non-cluster-launched kernels (the device function short-circuits).
+ */
+static void log_cluster_info_once(CUcontext /*ctx*/, CUfunction func, const char* func_name, unsigned int dyn_cx,
+                                  unsigned int dyn_cy, unsigned int dyn_cz) {
+  // The set tracks "have we already emitted the [CLUSTER] log for this
+  // CUfunction?". Both call sites (enter_kernel_launch, nvbit_at_graph_node_launch)
+  // hold *different* outer mutexes (cuda_event_mutex vs mutex), so we need our
+  // own lock to serialize concurrent inserts safely.
+  static std::unordered_set<CUfunction> g_cluster_logged_funcs;
+  static pthread_mutex_t g_cluster_logged_mutex = PTHREAD_MUTEX_INITIALIZER;
+  pthread_mutex_lock(&g_cluster_logged_mutex);
+  bool inserted = g_cluster_logged_funcs.insert(func).second;
+  pthread_mutex_unlock(&g_cluster_logged_mutex);
+  if (!inserted) {
+    return;
+  }
+  unsigned int cx = dyn_cx, cy = dyn_cy, cz = dyn_cz;
+  if (cx == 0 || cy == 0 || cz == 0) {
+    int rcw = 0, rch = 0, rcd = 0;
+    if (cuFuncGetAttribute(&rcw, CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_WIDTH, func) != CUDA_SUCCESS) rcw = 0;
+    if (cuFuncGetAttribute(&rch, CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_HEIGHT, func) != CUDA_SUCCESS) rch = 0;
+    if (cuFuncGetAttribute(&rcd, CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_DEPTH, func) != CUDA_SUCCESS) rcd = 0;
+    cx = rcw > 0 ? (unsigned int)rcw : 1;
+    cy = rch > 0 ? (unsigned int)rch : 1;
+    cz = rcd > 0 ? (unsigned int)rcd : 1;
+  }
+  unsigned int cluster_size = cx * cy * cz;
+  if (cluster_size <= 1) {
+    loprintf(
+        "[CLUSTER] WARNING: kernel=%s cluster_dim=(%u,%u,%u) size=%u - "
+        "cluster delay mode is a NO-OP for non-cluster-launched kernels; "
+        "use --delay-mode random to expose intra-CTA races instead\n",
+        func_name, cx, cy, cz, cluster_size);
+  } else {
+    loprintf(
+        "[CLUSTER] kernel=%s cluster_dim=(%u,%u,%u) size=%u - "
+        "cluster delay will affect 1 of %u CTAs per cluster\n",
+        func_name, cx, cy, cz, cluster_size, cluster_size);
+  }
 }
 
 /**
@@ -314,6 +400,18 @@ static void write_kernel_launch_event(const KernelFuncMetadata& meta, const Kern
 std::map<uint64_t, std::pair<CUcontext, CUfunction>> kernel_launch_to_func_map;
 std::map<uint64_t, uint32_t> kernel_launch_to_iter_map;
 std::map<uint64_t, KernelDimensions> kernel_launch_to_dimensions_map;
+
+// Cluster dim observed at the most recent cuLaunchKernelEx for a given
+// CUfunction (including stream-captured launches). This lets the graph-node
+// launch path see the launch-time cluster dim that Triton sets via
+// CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION, which cuFuncGetAttribute can't see
+// because Triton doesn't use the static __cluster_dims__ kernel attribute.
+struct ObservedClusterDim {
+  unsigned int x = 0, y = 0, z = 0;
+};
+
+std::unordered_map<CUfunction, ObservedClusterDim> g_func_to_observed_cluster;
+pthread_mutex_t g_cluster_obs_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 // map to store the iteration count for each kernel
 static std::map<CUfunction, uint32_t> kernel_iter_map;
@@ -694,12 +792,13 @@ bool instrument_function_if_needed(CUcontext ctx, CUfunction func) {
           shouldInjectDelay(instr, DELAY_INJECTION_PATTERNS)) {
         bool enabled;
         uint32_t delay_ns;
+        uint32_t cluster_seed = 0;
         bool found = true;
 
         if (is_delay_replay_mode()) {
           // Replay mode: always use config values, no random
           uint64_t pc_offset = instr->getOffset();
-          found = lookup_replay_config(replay_points, pc_offset, enabled, delay_ns);
+          found = lookup_replay_config(replay_points, pc_offset, enabled, delay_ns, cluster_seed);
           if (!found) {
             // Point not found in config - skip instrumentation for this point
             loprintf("Replay mode: kernel=%s pc=0x%lx NOT FOUND in config, skipping\n", unmangled_name, pc_offset);
@@ -709,25 +808,39 @@ bool instrument_function_if_needed(CUcontext ctx, CUfunction func) {
           enabled = generate_random_delay_enabled();
           delay_ns = g_delay_ns;
 
+          // Generate cluster seed only when cluster targeting is active —
+          // it's the per-instrumentation-point selector for which CTA gets
+          // delayed and is persisted to config for deterministic replay.
+          if (g_delay_cta_target == 1) {
+            cluster_seed = generate_cluster_seed();
+          }
+
           // Register the point for config output if kernel_delay_config was created
           if (kernel_delay_config) {
-            register_delay_instrumentation_point(kernel_delay_config, instr, delay_ns, enabled);
+            register_delay_instrumentation_point(kernel_delay_config, instr, delay_ns, enabled, cluster_seed);
           }
         }
 
         if (found && enabled) {
-          if (g_delay_mode == 1) {
-            // Random mode: per-thread random delay in [min_delay_ns, delay_ns]
+          if (g_delay_cta_target == 1) {
+            // Cluster targeting: delay one CTA per cluster (random per point via
+            // cluster_seed, or forced via g_cluster_cta_id). Distribution within
+            // the selected CTA is fixed (g_delay_mode==0) or per-thread random
+            // (g_delay_mode==1) — orthogonal to targeting.
+            instrument_cluster_delay_injection(instr, g_delay_min_ns, delay_ns, cluster_seed, g_cluster_cta_id,
+                                               /*use_fixed_delay=*/(g_delay_mode == 0) ? 1 : 0);
+          } else if (g_delay_mode == 1) {
+            // All-CTA random: per-thread random delay in [min_delay_ns, delay_ns]
             instrument_random_delay_injection(instr, g_delay_min_ns, delay_ns);
           } else {
-            // Fixed mode: same delay for all threads (original behavior)
+            // All-CTA fixed: same delay for all threads (original behavior)
             instrument_delay_injection(instr, delay_ns);
           }
         }
         if (found) {
-          loprintf("Delay injection: kernel=%s pc=0x%lx sass='%s' enabled=%s delay=%u%s\n", unmangled_name,
+          loprintf("Delay injection: kernel=%s pc=0x%lx sass='%s' enabled=%s delay=%u%s%s\n", unmangled_name,
                    instr->getOffset(), instr->getSass(), enabled ? "true" : "false", enabled ? delay_ns : 0,
-                   is_delay_replay_mode() ? " [REPLAY]" : "");
+                   g_delay_cta_target == 1 ? " [CLUSTER]" : "", is_delay_replay_mode() ? " [REPLAY]" : "");
         }
       }
     }
@@ -876,6 +989,22 @@ static bool enter_kernel_launch(CUcontext ctx, CUfunction func, uint64_t& kernel
   auto [cpu_callstack, callstack_source] = capture_cpu_callstack();
 
   CTXstate* ctx_state = ctx_state_map[ctx];
+
+  // Cluster targeting only: record cluster dim from launch attrs (including
+  // during stream capture) so graph-node launches can later look up the runtime
+  // cluster dim Triton set via CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION. The map
+  // is only read inside other `g_delay_cta_target == 1` branches, so skipping
+  // the mutex/insert when targeting all CTAs saves work on every launch.
+  if (g_delay_cta_target == 1) {
+    unsigned int cx = 0, cy = 0, cz = 0;
+    if (extract_cluster_dim_from_launch_ex(cbid, params, cx, cy, cz)) {
+      ObservedClusterDim d{cx, cy, cz};
+      pthread_mutex_lock(&g_cluster_obs_mutex);
+      g_func_to_observed_cluster[func] = d;
+      pthread_mutex_unlock(&g_cluster_obs_mutex);
+    }
+  }
+
   // no need to sync during stream capture or manual graph build, since no
   // kernel is actually launched.
   if (!stream_capture && !build_graph) {
@@ -923,6 +1052,14 @@ static bool enter_kernel_launch(CUcontext ctx, CUfunction func, uint64_t& kernel
           (uint64_t)ctx, pc, func_name, meta.kernel_checksum.c_str(), kernel_launch_id, p->gridDimX, p->gridDimY,
           p->gridDimZ, p->blockDimX, p->blockDimY, p->blockDimZ, meta.nregs,
           meta.shmem_static_nbytes + p->sharedMemBytes, (uint64_t)p->hStream);
+    }
+
+    // Cluster targeting: log cluster dimensions once per function (see
+    // log_cluster_info_once for details).
+    if (g_delay_cta_target == 1) {
+      unsigned int dyn_cx = 0, dyn_cy = 0, dyn_cz = 0;
+      extract_cluster_dim_from_launch_ex(cbid, params, dyn_cx, dyn_cy, dyn_cz);
+      log_cluster_info_once(ctx, func, func_name, dyn_cx, dyn_cy, dyn_cz);
     }
 
     // For histogram analysis, we need to map the kernel launch ID back to its
@@ -1275,6 +1412,24 @@ void nvbit_at_graph_node_launch(CUcontext ctx, CUfunction func, CUstream stream,
       (uint64_t)ctx, pc, func_name, global_kernel_launch_id, config.gridDimX, config.gridDimY, config.gridDimZ,
       config.blockDimX, config.blockDimY, config.blockDimZ, config.num_registers,
       config.shmem_static_nbytes + config.shmem_dynamic_nbytes, (uint64_t)stream);
+
+  // Cluster targeting: log cluster dims once per function. Look up the
+  // runtime cluster dim observed at the most recent cuLaunchKernelEx for this
+  // CUfunction (including the stream-capture launch that built this graph
+  // node). Falls back to the kernel-declared __cluster_dims__ inside the
+  // helper if neither source has dynamic info.
+  if (g_delay_cta_target == 1) {
+    unsigned int dyn_cx = 0, dyn_cy = 0, dyn_cz = 0;
+    pthread_mutex_lock(&g_cluster_obs_mutex);
+    auto it = g_func_to_observed_cluster.find(func);
+    if (it != g_func_to_observed_cluster.end()) {
+      dyn_cx = it->second.x;
+      dyn_cy = it->second.y;
+      dyn_cz = it->second.z;
+    }
+    pthread_mutex_unlock(&g_cluster_obs_mutex);
+    log_cluster_info_once(ctx, func, func_name, dyn_cx, dyn_cy, dyn_cz);
+  }
 
   // Store kernel launch mapping for graph node launches
   kernel_launch_to_func_map[global_kernel_launch_id] = {ctx, func};

--- a/src/delay_inject_config.cu
+++ b/src/delay_inject_config.cu
@@ -65,6 +65,9 @@ bool DelayInjectConfig::save_to_file(const std::string& filepath) const {
       point_json["sass"] = ip.sass;
       point_json["delay"] = ip.delay_ns;
       point_json["on"] = ip.enabled;
+      if (ip.cluster_seed != 0) {
+        point_json["cluster_seed"] = ip.cluster_seed;
+      }
       points_json[std::to_string(pc_offset)] = point_json;
     }
     kernel_json["instrumentation_points"] = points_json;
@@ -109,7 +112,8 @@ KernelDelayInjectConfig* create_kernel_delay_config(const std::string& kernel_na
   return &g_delay_inject_config.kernels[key];
 }
 
-void register_delay_instrumentation_point(KernelDelayInjectConfig* kdc, Instr* instr, uint32_t delay_ns, bool enabled) {
+void register_delay_instrumentation_point(KernelDelayInjectConfig* kdc, Instr* instr, uint32_t delay_ns, bool enabled,
+                                          uint32_t cluster_seed) {
   if (!kdc || !instr) {
     return;
   }
@@ -125,6 +129,7 @@ void register_delay_instrumentation_point(KernelDelayInjectConfig* kdc, Instr* i
   ip.sass = std::string(instr->getSass());
   ip.delay_ns = delay_ns;
   ip.enabled = enabled;
+  ip.cluster_seed = cluster_seed;
 }
 
 void finalize_delay_config() {
@@ -169,6 +174,7 @@ bool load_delay_config(const std::string& filepath) {
             ip.sass = point_json.value("sass", "");
             ip.delay_ns = point_json.value("delay", 0u);
             ip.enabled = point_json.value("on", false);
+            ip.cluster_seed = point_json.value("cluster_seed", 0u);
             kdc.instrumentation_points[ip.pc_offset] = ip;
           }
         }
@@ -219,7 +225,7 @@ const std::map<uint64_t, DelayInstrumentationPoint>* get_replay_instrumentation_
 }
 
 bool lookup_replay_config(const std::map<uint64_t, DelayInstrumentationPoint>* replay_points, uint64_t pc_offset,
-                          bool& enabled, uint32_t& delay_ns) {
+                          bool& enabled, uint32_t& delay_ns, uint32_t& cluster_seed) {
   if (!replay_points) {
     return false;
   }
@@ -228,6 +234,7 @@ bool lookup_replay_config(const std::map<uint64_t, DelayInstrumentationPoint>* r
   if (it != replay_points->end()) {
     enabled = it->second.enabled;
     delay_ns = it->second.delay_ns;
+    cluster_seed = it->second.cluster_seed;
     return true;
   }
 

--- a/src/env_config.cu
+++ b/src/env_config.cu
@@ -55,8 +55,15 @@ uint32_t g_delay_ns;
 // Minimum delay value in nanoseconds (floor for random mode)
 uint32_t g_delay_min_ns;
 
-// Delay mode: 0 = fixed (same delay for all threads), 1 = random (per-thread random)
+// Delay distribution: 0 = fixed (max_delay_ns for all delayed threads),
+// 1 = random (per-thread random in [min_delay_ns, max_delay_ns])
 int g_delay_mode;
+
+// CTA targeting: 0 = all CTAs delayed, 1 = one CTA per cluster delayed
+int g_delay_cta_target;
+
+// One-per-cluster CTA selection override (-1 = random per point, >= 0 = force CTA index)
+int g_cluster_cta_id;
 
 // Delay config dump output path (optional)
 std::string delay_dump_path;
@@ -320,23 +327,49 @@ void parse_delay_config() {
   }
   g_delay_min_ns = (uint32_t)delay_min_val;
 
-  // Parse delay mode: "random" (1, default) or "fixed" (0)
-  // random: each thread gets a random delay in [min_delay_ns, delay_ns] for asymmetric timing (recommended)
-  // fixed: all threads get the same delay (preserves relative timing, often masks races)
+  // Parse delay mode (distribution) and CTA targeting (orthogonal axes).
+  //
+  // Accepted CUTRACER_DELAY_MODE values:
+  //   "random"        — distribution=random (per-thread), targeting=all CTAs (default)
+  //   "fixed"         — distribution=fixed, targeting=all CTAs
+  //   "cluster"       — distribution=random, targeting=one CTA per cluster
+  //   "cluster_fixed" — distribution=fixed,  targeting=one CTA per cluster
+  //
+  // Internally these map to two independent globals (g_delay_mode for
+  // distribution, g_delay_cta_target for targeting) so the device function can
+  // dispatch on each independently.
   std::string delay_mode_str;
   get_var_str(delay_mode_str, "CUTRACER_DELAY_MODE", "random",
-              "Delay mode: 'random' (per-thread random delay, default) or 'fixed' (same delay for all threads)");
+              "Delay mode: 'random' (per-thread random, default), 'fixed' (uniform delay), "
+              "'cluster' (one CTA per cluster, random within), or 'cluster_fixed' (one CTA "
+              "per cluster, fixed within)");
   if (delay_mode_str == "random") {
     g_delay_mode = 1;
+    g_delay_cta_target = 0;
   } else if (delay_mode_str == "fixed") {
     g_delay_mode = 0;
+    g_delay_cta_target = 0;
+  } else if (delay_mode_str == "cluster") {
+    g_delay_mode = 1;
+    g_delay_cta_target = 1;
+  } else if (delay_mode_str == "cluster_fixed") {
+    g_delay_mode = 0;
+    g_delay_cta_target = 1;
   } else {
     fprintf(stderr,
             "FATAL: Invalid CUTRACER_DELAY_MODE '%s'.\n"
-            "Valid values: 'random' (default) or 'fixed'.\n",
+            "Valid values: 'random' (default), 'fixed', 'cluster', or 'cluster_fixed'.\n",
             delay_mode_str.c_str());
     exit(1);
   }
+
+  // One-per-cluster CTA selection override (only meaningful when targeting=one_per_cluster)
+  get_var_int(g_cluster_cta_id, "CUTRACER_CLUSTER_CTA_ID", -1,
+              "Cluster targeting override: force every instrumentation point to delay this CTA "
+              "index in every cluster (-1 = random per point via cluster_seed). "
+              "Only meaningful with --delay-mode cluster or cluster_fixed. "
+              "When set together with --delay-load-path, the override wins — replay is no "
+              "longer bit-identical to the recording.");
 
   // Get delay config dump output path
   get_var_str(delay_dump_path, "CUTRACER_DELAY_DUMP_PATH", "", "Output path to dump delay config JSON for replay");
@@ -351,6 +384,19 @@ void parse_delay_config() {
             "FATAL: Both CUTRACER_DELAY_DUMP_PATH and CUTRACER_DELAY_LOAD_PATH are set.\n"
             "Please use only one: DUMP for recording, LOAD for replay.\n");
     exit(1);
+  }
+
+  // Warn if cluster CTA override is combined with replay: the override wins
+  // over per-point cluster_seed loaded from config, so replay is no longer
+  // bit-identical to the recording.
+  if (!delay_load_path.empty() && g_cluster_cta_id >= 0 && g_delay_cta_target == 1) {
+    fprintf(stderr,
+            "WARNING: CUTRACER_CLUSTER_CTA_ID=%d is set together with CUTRACER_DELAY_LOAD_PATH.\n"
+            "  The override forces every instrumentation point to delay CTA %d, ignoring the\n"
+            "  per-point cluster_seed values stored in the replay config. Replay is therefore\n"
+            "  NOT bit-identical to the recording. Unset CUTRACER_CLUSTER_CTA_ID (or set to -1)\n"
+            "  for exact replay.\n",
+            g_cluster_cta_id, g_cluster_cta_id);
   }
 }
 

--- a/src/inject_funcs.cu
+++ b/src/inject_funcs.cu
@@ -354,3 +354,112 @@ extern "C" __device__ __noinline__ void instrument_delay_random(int pred, uint32
   }
 #endif
 }
+
+/**
+ * @brief Device function to inject a random delay on exactly one CTA within a cluster.
+ *
+ * Uses cluster_ctaid/cluster_nctaid PTX registers to determine the CTA's
+ * position within its cluster. A host-provided seed selects which CTA index
+ * in the cluster receives the delay; all other CTAs skip entirely. This
+ * creates timing asymmetry between CTAs in the same cluster, exposing
+ * missing inter-CTA synchronization.
+ *
+ * If the cluster has only one CTA (no clustering), the delay is skipped
+ * since there is no inter-CTA synchronization to test.
+ *
+ * Within the selected CTA, each thread still gets a per-thread random
+ * delay (same as instrument_delay_random) for additional timing skew.
+ *
+ * @param pred Guard predicate value (from nvbit_add_call_arg_guard_pred_val)
+ * @param min_delay_ns Minimum delay in nanoseconds (floor)
+ * @param max_delay_ns Maximum delay in nanoseconds (ceiling)
+ * @param cluster_seed Host-generated seed that determines which CTA in the
+ *        cluster gets delayed. Stored in delay config JSON for replay.
+ */
+extern "C" __device__ __noinline__ void instrument_delay_random_cluster(int pred, uint32_t min_delay_ns,
+                                                                        uint32_t max_delay_ns, uint32_t cluster_seed,
+                                                                        int32_t cta_id_override,
+                                                                        int32_t use_fixed_delay) {
+  // The %cluster_ctaid / %cluster_nctaid PTX special registers used by
+  // get_cluster_ctaid()/get_cluster_nctaid() require sm_90+. On older arches
+  // (e.g. sm_80) ptxas rejects them, so compile this whole body into a no-op
+  // there. Cluster mode itself is meaningless on pre-Hopper hardware.
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  if (!pred) {
+    return;
+  }
+
+  // Determine cluster geometry
+  int4 cluster_nctaid = get_cluster_nctaid();
+  int total_ctas = cluster_nctaid.x * cluster_nctaid.y * cluster_nctaid.z;
+
+  // No clustering or single-CTA cluster — skip delay
+  if (total_ctas <= 1) {
+    return;
+  }
+
+  // Compute this CTA's linear index within the cluster
+  int4 cluster_ctaid = get_cluster_ctaid();
+  int my_cta_linear =
+      cluster_ctaid.x + cluster_ctaid.y * cluster_nctaid.x + cluster_ctaid.z * cluster_nctaid.x * cluster_nctaid.y;
+
+  // Select which CTA in the cluster gets delayed. Precedence:
+  //   1. cta_id_override >= 0 (set host-side via --delay-cluster-cta-id):
+  //      target_cta = cta_id_override % total_ctas. ALWAYS WINS — including
+  //      in --delay-load-path replay mode. Setting the override during replay
+  //      intentionally overrides the recorded cluster_seed for every point,
+  //      so replay is no longer bit-identical to the recording. Useful for
+  //      A/B-bisecting "did the bug fire because CTA X was delayed?".
+  //   2. cluster_seed (host-generated per instrumentation point in record
+  //      mode, loaded from config in replay mode):
+  //      target_cta = cluster_seed % total_ctas. Deterministic across runs
+  //      that share the same delay config AND do not set the override.
+  int target_cta = (cta_id_override >= 0) ? (cta_id_override % total_ctas) : (int)(cluster_seed % (uint32_t)total_ctas);
+
+  if (my_cta_linear != target_cta) {
+    return;  // Not the selected CTA, no delay
+  }
+
+  // Selected CTA: compute delay either as fixed (= max_delay_ns) or per-thread
+  // random in [min_delay_ns, max_delay_ns]. Cluster targeting is orthogonal to
+  // distribution: cluster + fixed delays the selected CTA's threads in lockstep,
+  // cluster + random adds intra-CTA timing skew on top of inter-CTA targeting.
+  uint32_t delay;
+  if (use_fixed_delay) {
+    delay = max_delay_ns;
+  } else {
+    uint32_t seed = (uint32_t)clock() ^ (threadIdx.x * 2654435761u) ^ (threadIdx.y * 2246822519u) ^
+                    (threadIdx.z * 3266489917u) ^ (blockIdx.x * 668265263u) ^ (blockIdx.y * 374761393u) ^
+                    (blockIdx.z * 1103515245u);
+
+    seed ^= seed << 13;
+    seed ^= seed >> 17;
+    seed ^= seed << 5;
+
+    uint32_t range = max_delay_ns - min_delay_ns;
+    delay = min_delay_ns + (range > 0 ? seed % (range + 1) : 0);
+  }
+
+  // CUDA __nanosleep has an implementation-defined per-call maximum
+  // (~1ms in practice on Hopper/Blackwell). For larger requested delays we
+  // loop in 1ms chunks so a 50ms or 500ms request actually sleeps that long
+  // instead of silently capping at the hardware limit.
+  const uint32_t CHUNK_NS = 1000000u;  // 1 ms
+  uint32_t remaining = delay;
+  while (remaining > CHUNK_NS) {
+    __nanosleep(CHUNK_NS);
+    remaining -= CHUNK_NS;
+  }
+  if (remaining > 0) {
+    __nanosleep(remaining);
+  }
+#else
+  // Reference args to silence unused-parameter warnings under -Wall.
+  (void)pred;
+  (void)min_delay_ns;
+  (void)max_delay_ns;
+  (void)cluster_seed;
+  (void)cta_id_override;
+  (void)use_fixed_delay;
+#endif
+}

--- a/src/instrument.cu
+++ b/src/instrument.cu
@@ -220,6 +220,25 @@ void instrument_random_delay_injection(Instr* instr, uint32_t min_delay_ns, uint
   nvbit_add_call_arg_const_val32(instr, max_delay_ns);
 }
 
+void instrument_cluster_delay_injection(Instr* instr, uint32_t min_delay_ns, uint32_t max_delay_ns,
+                                        uint32_t cluster_seed, int32_t cta_id_override, int32_t use_fixed_delay) {
+  /* insert call to the cluster-level delay function */
+  nvbit_insert_call(instr, "instrument_delay_random_cluster",
+                    get_ipoint_from_config(InstrumentType::RANDOM_DELAY, IPOINT_BEFORE));
+  /* guard predicate value */
+  nvbit_add_call_arg_guard_pred_val(instr);
+  /* min delay in nanoseconds */
+  nvbit_add_call_arg_const_val32(instr, min_delay_ns);
+  /* max delay in nanoseconds */
+  nvbit_add_call_arg_const_val32(instr, max_delay_ns);
+  /* seed for selecting which CTA in the cluster gets delayed */
+  nvbit_add_call_arg_const_val32(instr, cluster_seed);
+  /* host-side CTA selection override: -1 = random via seed, >=0 = force this CTA index */
+  nvbit_add_call_arg_const_val32(instr, (uint32_t)cta_id_override);
+  /* delay distribution: 0 = per-thread random in [min, max], 1 = fixed = max */
+  nvbit_add_call_arg_const_val32(instr, (uint32_t)use_fixed_delay);
+}
+
 /**
  * @brief Instruments a memory instruction to trace memory access with values.
  *


### PR DESCRIPTION
Summary:

Add a new `--delay-mode cluster` that delays only one randomly-selected CTA within each cluster while other CTAs proceed at normal speed. This creates timing asymmetry between CTAs in the same cluster, helping expose missing inter-CTA synchronization bugs.

Key changes:
- New device function `instrument_delay_random_cluster` that uses `cluster_ctaid`/`cluster_nctaid` PTX registers to select one CTA per cluster
- Host-side `instrument_cluster_delay_injection` passes min/max delay + seed
- `cluster_seed` stored in delay config JSON for deterministic replay
- `--delay-mode cluster` added to CLI (alongside existing `random`/`fixed`)

Cluster-launch detection and warning:
The device function correctly short-circuits when `cluster_nctaid <= 1`, but this happens silently — without a host-side signal, users running `--delay-mode cluster` against a non-cluster-launched kernel see no delay applied and no indication that anything was wrong (we wasted ~30 minutes of test runs on exactly this). To prevent this class of silent-no-op failure, this diff also adds a host-side, one-time-per-`CUfunction` log of the runtime cluster dimensions. Dims are read from `CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION` on `cuLaunchKernelEx` (including launches captured into a CUDA graph during stream capture) and stashed per `CUfunction`, so graph-node launches can later look them up — necessary because Triton sets cluster dims at launch time, not via the static `__cluster_dims__` kernel attribute that `cuFuncGetAttribute` would surface. The helper falls back to `cuFuncGetAttribute(CU_FUNC_ATTRIBUTE_REQUIRED_CLUSTER_*)` for kernels that do declare `__cluster_dims__`. Example output:

```
[CLUSTER] kernel=_tlx_grouped_gemm_wgrad cluster_dim=(2,1,1) size=2 - cluster delay will affect 1 of 2 CTAs per cluster
[CLUSTER] WARNING: kernel=foo cluster_dim=(1,1,1) size=1 - cluster delay mode is a NO-OP for non-cluster-launched kernels; use --delay-mode random to expose intra-CTA races instead
```

Differential Revision: D101391851
