### PR TITLE
Sync install_cuda.sh with PyTorch upstream (#208)

### DIFF
--- a/.github/workflows/test_install_cuda.yml
+++ b/.github/workflows/test_install_cuda.yml
@@ -20,7 +20,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                cuda_version: ["12.8", "13.0"]
+                cuda_version: ["12.8", "13.2"]
 
         steps:
             - name: Checkout code

--- a/scripts/install_cuda.sh
+++ b/scripts/install_cuda.sh
@@ -51,7 +51,7 @@ declare -A CUDA_FULL_VERSION=(
   ["12.8"]="12.8.1"
   ["12.9"]="12.9.1"
   ["13.0"]="13.0.2"
-  ["13.2"]="13.2.0"
+  ["13.2"]="13.2.1"
 )
 
 declare -A CUDA_RUNFILE=(
@@ -59,7 +59,7 @@ declare -A CUDA_RUNFILE=(
   ["12.8"]="cuda_12.8.1_570.124.06_linux"
   ["12.9"]="cuda_12.9.1_575.57.08_linux"
   ["13.0"]="cuda_13.0.2_580.95.05_linux"
-  ["13.2"]="cuda_13.2.0_595.45.04_linux"
+  ["13.2"]="cuda_13.2.1_595.58.03_linux"
 )
 
 declare -A CUDNN_VERSIONS=(
@@ -382,6 +382,13 @@ function install_nccl {
   fi
 
   echo "Installing NCCL for CUDA ${CUDA_VERSION}..."
+
+  # Use the NCCL version for CUDA 12.6 due to sm50 support.
+  # Synced with PyTorch .ci/docker/common/install_nccl.sh
+  if [[ ${CUDA_VERSION:0:4} == "12.6" ]]; then
+    NCCL_VERSION="v2.29.3-1"
+  fi
+
   if [[ -z "${NCCL_VERSION}" ]]; then
     error_exit "NCCL_VERSION is empty"
   fi

--- a/scripts/setup_local_skills.sh
+++ b/scripts/setup_local_skills.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Symlink CUTracer's in-repo SKILL.md files into the user's home so that
+# Devmate (~/.llms/skills) and Claude Code (~/.claude/skills) load them
+# globally — not only when CUTracer files are in scope.
+#
+# Run once per devserver. Idempotent (uses `ln -sfn`).
+#
+# Usage:
+#   bash scripts/setup_local_skills.sh
+#
+# After running:
+#   ~/.llms/skills/sync_install_cuda  → fbsource/.../CUTracer/.llms/skills/sync_install_cuda
+#   ~/.claude/skills/sync-install-cuda → fbsource/.../CUTracer/.claude/skills/sync-install-cuda
+#
+# Edits to the canonical files in the repo take effect immediately —
+# the symlink is followed to the live file each time the agent loads it.
+
+set -euo pipefail
+
+# Resolve the CUTracer repo root from this script's location.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+DEVMATE_SRC="${REPO_DIR}/.llms/skills/sync_install_cuda"
+CLAUDE_SRC="${REPO_DIR}/.claude/skills/sync-install-cuda"
+
+DEVMATE_DST_DIR="${HOME}/.llms/skills"
+CLAUDE_DST_DIR="${HOME}/.claude/skills"
+
+DEVMATE_DST="${DEVMATE_DST_DIR}/sync_install_cuda"
+CLAUDE_DST="${CLAUDE_DST_DIR}/sync-install-cuda"
+
+echo "🔗 Setting up CUTracer agent skills"
+echo "    repo:      ${REPO_DIR}"
+echo "    home:      ${HOME}"
+
+# Sanity: source dirs must exist before we make symlinks.
+for src in "${DEVMATE_SRC}" "${CLAUDE_SRC}"; do
+  if [ ! -d "${src}" ]; then
+    echo "❌ Missing source skill directory: ${src}" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "${DEVMATE_DST_DIR}" "${CLAUDE_DST_DIR}"
+
+# `ln -sfn` semantics:
+#   -s: symbolic
+#   -f: force (replace existing)
+#   -n: when target is a directory symlink, replace it instead of nesting inside
+ln -sfn "${DEVMATE_SRC}" "${DEVMATE_DST}"
+ln -sfn "${CLAUDE_SRC}"  "${CLAUDE_DST}"
+
+echo "✅ Devmate skill: ${DEVMATE_DST} -> $(readlink "${DEVMATE_DST}")"
+echo "✅ Claude  skill: ${CLAUDE_DST} -> $(readlink "${CLAUDE_DST}")"
+echo
+echo "Both skills are now globally active. To verify:"
+echo "  ls -la ${DEVMATE_DST}"
+echo "  ls -la ${CLAUDE_DST}"
+echo
+echo "To remove later:"
+echo "  rm ${DEVMATE_DST} ${CLAUDE_DST}"


### PR DESCRIPTION
Summary:

- CUDA 13.2: 13.2.0 -> 13.2.1 (driver 595.45.04 -> 595.58.03);
  runfile cuda_13.2.0_595.45.04_linux -> cuda_13.2.1_595.58.03_linux
- Add CUDA-12.6 NCCL pin override v2.29.3-1 (sm50 support bug fix,
  synced from PyTorch .ci/docker/common/install_nccl.sh)

Skipped:
- CUDA 12.4 (older than CUTracer's lowest supported version 12.6)

Reviewed By: wlei-llvm

Differential Revision: D101714837
