### PR TITLE
Fix CodeQL security warnings in CI workflows and trace writer

### DIFF
--- a/.github/workflows/check-nvbit-update.yml
+++ b/.github/workflows/check-nvbit-update.yml
@@ -117,7 +117,7 @@ jobs:
         if: |
           (steps.check.outputs.update_needed == 'true' || inputs.force == true)
           && inputs.dry_run != true
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "[deps] Update NVBit to ${{ steps.latest.outputs.version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   format-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_install_cuda.yml
+++ b/.github/workflows/test_install_cuda.yml
@@ -13,6 +13,9 @@ on:
             - ".github/workflows/test_install_cuda.yml"
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
     test-install-cuda:
         runs-on: 8-core-ubuntu

--- a/src/trace_writer.cpp
+++ b/src/trace_writer.cpp
@@ -43,10 +43,18 @@ TraceWriter::TraceWriter(const std::string& filename, int trace_mode, size_t buf
   if (trace_mode_ == TraceMode::TEXT) {
     // Mode 0: Text format - use FILE* for fprintf compatibility
     actual_filename = filename + ".log";
-    file_handle_ = fopen(actual_filename.c_str(), "w");
-
+    int text_fd = open(actual_filename.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    if (text_fd < 0) {
+      fprintf(stderr, "TraceWriter: Failed to open %s (errno=%d: %s)\n", actual_filename.c_str(), errno,
+              strerror(errno));
+      enabled_ = false;
+      return;
+    }
+    file_handle_ = fdopen(text_fd, "w");
     if (!file_handle_) {
-      fprintf(stderr, "TraceWriter: Failed to open %s\n", actual_filename.c_str());
+      fprintf(stderr, "TraceWriter: Failed to fdopen %s (errno=%d: %s)\n", actual_filename.c_str(), errno,
+              strerror(errno));
+      ::close(text_fd);
       enabled_ = false;
       return;
     }


### PR DESCRIPTION
Summary:
Fix three categories of CodeQL findings from the OSS repo:

1. **File permissions (cpp/world-writable-file-creation):** `fopen("w")` in trace_writer.cpp creates files with mode 0666 (before umask). Replace with `open(O_CREAT|O_WRONLY|O_TRUNC, 0644)` + `fdopen()` to explicitly restrict permissions, consistent with the existing NDJSON code path.

2. **Missing workflow permissions (actions/missing-workflow-permissions):** Add `permissions: contents: read` to test.yml and test_install_cuda.yml to follow least-privilege principle. check-nvbit-update.yml already had permissions set.

3. **Unpinned action tag (actions/unpinned-tag):** Pin `peter-evans/create-pull-request` from `v8` to its commit SHA `5f6978faf089d4d20b00c7766989d076bb2fc7f1` to prevent supply-chain attacks.

Differential Revision: D101907984


