### PR TITLE
Add --delay-patterns flag for arbitrary instruction delay injection

### DIFF
--- a/include/env_config.h
+++ b/include/env_config.h
@@ -143,6 +143,10 @@ extern int g_delay_cta_target;
 // is emitted in that case (see init_config_from_env).
 extern int g_cluster_cta_id;
 
+// User-specified delay injection patterns (optional, overrides DELAY_INJECTION_PATTERNS)
+// Comma-separated SASS substrings, e.g. "SYNCS.EXCH,BAR.SYNC"
+extern std::vector<std::string> g_delay_patterns;
+
 // Delay dump output path (optional)
 // If set, instrumentation points will be written to this JSON file for later replay
 extern std::string delay_dump_path;

--- a/include/instrument.h
+++ b/include/instrument.h
@@ -137,6 +137,7 @@ void instrument_cluster_delay_injection(Instr* instr, uint32_t min_delay_ns, uin
  * @brief SASS instruction patterns for delay injection.
  */
 static const std::vector<const char*> DELAY_INJECTION_PATTERNS = {
+    "SYNCS.EXCH",                      // mbarrier init
     "SYNCS.PHASECHK.TRANS64.TRYWAIT",  // mbarrier try_wait
     "SYNCS.ARRIVE.TRANS64.RED.A1T0",   // mbarrier arrive
     "UTMASTG",                         // TMA store

--- a/python/cutracer/runner.py
+++ b/python/cutracer/runner.py
@@ -97,6 +97,7 @@ def _build_cutracer_env(
     delay_min_ns: Optional[int] = None,
     delay_mode: Optional[str] = None,
     delay_cluster_cta_id: Optional[int] = None,
+    delay_patterns: Optional[str] = None,
     delay_dump_path: Optional[str] = None,
     delay_load_path: Optional[str] = None,
     cpu_callstack: Optional[str] = None,
@@ -136,6 +137,8 @@ def _build_cutracer_env(
         env["CUTRACER_DELAY_MODE"] = delay_mode
     if delay_cluster_cta_id is not None:
         env["CUTRACER_CLUSTER_CTA_ID"] = str(delay_cluster_cta_id)
+    if delay_patterns is not None:
+        env["CUTRACER_DELAY_PATTERNS"] = delay_patterns
     if delay_dump_path is not None:
         env["CUTRACER_DELAY_DUMP_PATH"] = delay_dump_path
     if delay_load_path is not None:
@@ -184,6 +187,7 @@ def _print_config_summary(env: dict) -> None:
         "CUTRACER_DELAY_MIN_NS",
         "CUTRACER_DELAY_MODE",
         "CUTRACER_CLUSTER_CTA_ID",
+        "CUTRACER_DELAY_PATTERNS",
         "CUTRACER_DELAY_DUMP_PATH",
         "CUTRACER_DELAY_LOAD_PATH",
         "CUTRACER_CPU_CALLSTACK",
@@ -292,6 +296,12 @@ _CUTRACER_OPTIONS = [
         "to the recording. Unset (or omit) for exact replay.",
     ),
     click.option(
+        "--delay-patterns",
+        default=None,
+        help="Comma-separated SASS instruction substrings for delay injection "
+        "(overrides built-in patterns). Example: 'SYNCS.EXCH' for mbarrier init only",
+    ),
+    click.option(
         "--delay-dump-path",
         default=None,
         help="Output path to dump delay config JSON for replay",
@@ -386,6 +396,7 @@ def trace_command(
     delay_min_ns: Optional[int],
     delay_mode: Optional[str],
     delay_cluster_cta_id: Optional[int],
+    delay_patterns: Optional[str],
     delay_dump_path: Optional[str],
     delay_load_path: Optional[str],
     cpu_callstack: Optional[str],
@@ -441,6 +452,7 @@ def trace_command(
         delay_min_ns=delay_min_ns,
         delay_mode=delay_mode,
         delay_cluster_cta_id=delay_cluster_cta_id,
+        delay_patterns=delay_patterns,
         delay_dump_path=delay_dump_path,
         delay_load_path=delay_load_path,
         cpu_callstack=cpu_callstack,

--- a/src/cutracer.cu
+++ b/src/cutracer.cu
@@ -1098,7 +1098,7 @@ static bool enter_kernel_launch(CUcontext ctx, CUfunction func, uint64_t& kernel
 
     // Cluster targeting: log cluster dimensions once per function (see
     // log_cluster_info_once for details).
-    if (g_delay_cta_target == 1) {
+    if (should_instrument && g_delay_cta_target == 1) {
       unsigned int dyn_cx = 0, dyn_cy = 0, dyn_cz = 0;
       extract_cluster_dim_from_launch_ex(cbid, params, dyn_cx, dyn_cy, dyn_cz);
       log_cluster_info_once(ctx, func, func_name, dyn_cx, dyn_cy, dyn_cz);
@@ -1447,7 +1447,7 @@ void nvbit_at_graph_node_launch(CUcontext ctx, CUfunction func, CUstream stream,
   nvbit_get_func_config(ctx, func, &config);
 
   loprintf(
-      "MEMTRACE: CTX 0x%016lx - LAUNCH - Kernel pc 0x%016lx - "
+      "CUTracer: CTX 0x%016lx - LAUNCH - Kernel pc 0x%016lx - "
       "Kernel name %s - grid launch id %ld - grid size %d,%d,%d "
       "- block size %d,%d,%d - nregs %d - shmem %d - cuda stream "
       "id %ld\n",

--- a/src/cutracer.cu
+++ b/src/cutracer.cu
@@ -524,6 +524,33 @@ static bool should_instrument_instr_by_category(Instr* instr) {
   return should_instrument;
 }
 
+/**
+ * @brief Check if an instruction should receive delay injection.
+ *
+ * Uses user-specified patterns (g_delay_patterns / --delay-patterns) if provided,
+ * otherwise falls back to the built-in DELAY_INJECTION_PATTERNS list.
+ * Special case: "*" matches all instructions.
+ */
+static bool shouldInjectDelayWithPatterns(Instr* instr) {
+  static std::vector<const char*> user_patterns_cstr;
+  static bool user_patterns_built = false;
+  static bool delay_all_instructions = false;
+  if (!user_patterns_built && !g_delay_patterns.empty()) {
+    delay_all_instructions = (g_delay_patterns.size() == 1 && g_delay_patterns[0] == "*");
+    if (!delay_all_instructions) {
+      for (const auto& p : g_delay_patterns) {
+        user_patterns_cstr.push_back(p.c_str());
+      }
+    }
+    user_patterns_built = true;
+  }
+  if (delay_all_instructions) {
+    return true;
+  }
+  const auto& active_patterns = g_delay_patterns.empty() ? DELAY_INJECTION_PATTERNS : user_patterns_cstr;
+  return shouldInjectDelay(instr, active_patterns);
+}
+
 /* ===== Main Functionality ===== */
 
 /**
@@ -830,8 +857,7 @@ bool instrument_function_if_needed(CUcontext ctx, CUfunction func) {
       }
 
       // Delay instrumentation for synchronization instructions
-      if (is_instrument_type_enabled(InstrumentType::RANDOM_DELAY) &&
-          shouldInjectDelay(instr, DELAY_INJECTION_PATTERNS)) {
+      if (is_instrument_type_enabled(InstrumentType::RANDOM_DELAY) && shouldInjectDelayWithPatterns(instr)) {
         bool enabled;
         uint32_t delay_ns;
         uint32_t cluster_seed = 0;

--- a/src/env_config.cu
+++ b/src/env_config.cu
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 
 #include <filesystem>
+#include <sstream>
 
 #include "env_config.h"
 #include "instr_category.h"
@@ -64,6 +65,9 @@ int g_delay_cta_target;
 
 // One-per-cluster CTA selection override (-1 = random per point, >= 0 = force CTA index)
 int g_cluster_cta_id;
+
+// User-specified delay injection patterns
+std::vector<std::string> g_delay_patterns;
 
 // Delay config dump output path (optional)
 std::string delay_dump_path;
@@ -370,6 +374,23 @@ void parse_delay_config() {
               "Only meaningful with --delay-mode cluster or cluster_fixed. "
               "When set together with --delay-load-path, the override wins — replay is no "
               "longer bit-identical to the recording.");
+
+  // Parse user-specified delay patterns (optional, overrides DELAY_INJECTION_PATTERNS)
+  std::string delay_patterns_str;
+  get_var_str(delay_patterns_str, "CUTRACER_DELAY_PATTERNS", "",
+              "Comma-separated SASS substrings for delay injection (overrides built-in patterns)");
+  if (!delay_patterns_str.empty()) {
+    std::istringstream ss(delay_patterns_str);
+    std::string token;
+    while (std::getline(ss, token, ',')) {
+      while (!token.empty() && std::isspace(token.front())) token.erase(0, 1);
+      while (!token.empty() && std::isspace(token.back())) token.pop_back();
+      if (!token.empty()) {
+        g_delay_patterns.push_back(token);
+      }
+    }
+    loprintf("Using %zu user-specified delay patterns\n", g_delay_patterns.size());
+  }
 
   // Get delay config dump output path
   get_var_str(delay_dump_path, "CUTRACER_DELAY_DUMP_PATH", "", "Output path to dump delay config JSON for replay");


### PR DESCRIPTION
Summary:
Add a --delay-patterns CLI flag that lets users specify arbitrary SASS instruction substrings for delay injection, overriding the built-in DELAY_INJECTION_PATTERNS list. This enables testing specific instruction types in isolation without editing source code.

Special case: --delay-patterns "*" matches all instructions, enabling random delay injection on a random 50% subset of ALL SASS instructions in the kernel.

Also adds SYNCS.EXCH (mbarrier init) to the built-in delay injection patterns, and adds instrument_delay_random_cluster support for inter-CTA timing asymmetry testing.

Changes:
- runner.py: new --delay-patterns click option, plumbed through env var CUTRACER_DELAY_PATTERNS
- env_config.h/cu: new g_delay_patterns global, parsed from comma-separated env var
- cutracer.cu: runtime pattern selection with "*" wildcard support
- instrument.h: added SYNCS.EXCH to DELAY_INJECTION_PATTERNS

Reviewed By: FindHao

Differential Revision: D101567546


