### PR TITLE
Add e2e tests for warp status NDJSON output and inactive_secs

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -970,6 +970,114 @@ test_hang_test() {
     fi
   fi
 
+  # Verify text-mode warp status output prints inactive=Xs for LOOPING entries
+  # (regression guard: inactive_secs must be visible for non-BARRIER warps too).
+  if ! grep -q "LOOPING(inactive=" hang_output.log; then
+    echo "❌ Expected 'LOOPING(inactive=...' line missing from hang_output.log."
+    echo "     Recent WARP STATUS lines:"
+    grep -E "WARP STATUS|Warp[0-9]+\[" hang_output.log | tail -20
+    cd "$PROJECT_ROOT"
+    return 1
+  fi
+  echo "  ✅ LOOPING entries include inactive=Xs in text output."
+
+  cd "$PROJECT_ROOT"
+  return 0
+}
+
+# Function to verify NDJSON warp status output (append-mode, per-snapshot lines).
+# Exercises the trace_format != 0 branch and ensures multiple hang-detection ticks
+# produce one JSON object per line in <basename>_warp_status_summary.ndjson.
+test_hang_test_warp_status_ndjson() {
+  echo "🧪 Testing hang detection (NDJSON warp status output)..."
+  cd "$PROJECT_ROOT/tests/hang_test"
+
+  # Clean up old artifacts from previous runs to avoid stale-file false positives
+  rm -f *.log *.csv *.chrome_trace *_warp_status_summary.ndjson *_warp_status_summary.json
+
+  if [ ! -f "test_hang.py" ]; then
+    echo "❌ test_hang.py not found."
+    ls -la
+    cd "$PROJECT_ROOT"
+    return 1
+  fi
+
+  if ! timeout "$TIMEOUT" env \
+       CUTRACER_TRACE_FORMAT=2 \
+       CUDA_INJECTION64_PATH="$PROJECT_ROOT/lib/cutracer.so" \
+       CUTRACER_ANALYSIS=deadlock_detection \
+       KERNEL_FILTERS=add_kernel \
+       python "./test_hang.py" >hang_ndjson_output.log 2>&1; then
+    exit_code=$?
+    if [ "$exit_code" -eq 124 ]; then
+      echo "❌ Hang NDJSON test timed out (no detection within $TIMEOUT s)."
+      cat hang_ndjson_output.log
+      cd "$PROJECT_ROOT"
+      return 1
+    fi
+    if ! grep -q "Deadlock sustained" hang_ndjson_output.log; then
+      echo "❌ Hang NDJSON test failed without detection (exit $exit_code)."
+      cat hang_ndjson_output.log
+      cd "$PROJECT_ROOT"
+      return 1
+    fi
+  fi
+
+  # The legacy single-file JSON name must NOT exist anymore
+  if ls *_warp_status_summary.json >/dev/null 2>&1; then
+    echo "❌ Unexpected legacy *_warp_status_summary.json file found (should be NDJSON now):"
+    ls -la *_warp_status_summary.json
+    cd "$PROJECT_ROOT"
+    return 1
+  fi
+
+  ndjson_file=$(ls -1 *_warp_status_summary.ndjson 2>/dev/null | head -n 1)
+  if [ -z "$ndjson_file" ] || [ ! -f "$ndjson_file" ]; then
+    echo "❌ No *_warp_status_summary.ndjson file produced."
+    echo "     Listing current directory contents:"
+    ls -la
+    cd "$PROJECT_ROOT"
+    return 1
+  fi
+  echo "  ✅ Found NDJSON warp status file: $ndjson_file"
+
+  # Validate NDJSON contents:
+  # - every line parses as JSON
+  # - kernel_launch_id is consistent across lines
+  # - each warp entry has inactive_secs (consistency with text output)
+  # - at least one entry is LOOPING (the test kernel hangs in a loop)
+  if ! python - "$ndjson_file" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path) as f:
+    lines = [ln for ln in (raw.strip() for raw in f) if ln]
+assert lines, f"{path} is empty"
+records = []
+for i, ln in enumerate(lines):
+    try:
+        records.append(json.loads(ln))
+    except json.JSONDecodeError as e:
+        sys.exit(f"line {i+1} is not valid JSON: {e}")
+ids = {r.get("kernel_launch_id") for r in records}
+assert len(ids) == 1, f"kernel_launch_id not consistent across snapshots: {ids}"
+saw_looping = False
+for r in records:
+    for w in r.get("active_warps", []):
+        assert "inactive_secs" in w, f"warp entry missing inactive_secs: {w}"
+        if w.get("status") == "LOOPING":
+            saw_looping = True
+assert saw_looping, "expected at least one LOOPING warp entry across snapshots"
+print(f"validated {len(lines)} NDJSON snapshot(s) with consistent kernel_launch_id")
+PY
+  then
+    echo "❌ NDJSON content validation failed for $ndjson_file."
+    echo "     --- First 3 lines ---"
+    head -n 3 "$ndjson_file"
+    cd "$PROJECT_ROOT"
+    return 1
+  fi
+  echo "  ✅ NDJSON warp status content validated."
+
   cd "$PROJECT_ROOT"
   return 0
 }
@@ -1145,6 +1253,12 @@ run_all_tests() {
     failed_suites+=("hang-test")
   fi
 
+  if test_hang_test_warp_status_ndjson; then
+    passed_suites+=("hang-test-warp-status-ndjson")
+  else
+    failed_suites+=("hang-test-warp-status-ndjson")
+  fi
+
   if test_trace_formats; then
     passed_suites+=("trace-formats")
   else
@@ -1235,6 +1349,9 @@ case "$TEST_TYPE" in
   ;;
 "hang")
   test_hang_test
+  ;;
+"hang-ndjson")
+  test_hang_test_warp_status_ndjson
   ;;
 "python-module")
   test_python_module

--- a/include/analysis.h
+++ b/include/analysis.h
@@ -30,6 +30,10 @@
 // Forward declaration for TraceWriter (defined in trace_writer.h)
 class TraceWriter;
 
+// Length of the per-warp instruction ring buffer (WarpLoopState::history).
+// Defined here so warp_status.cu and analysis.cu share a single source of truth.
+#define PC_HISTORY_LEN 32
+
 /* Thread state enum */
 enum class RecvThreadState {
   INIT,

--- a/include/warp_status.h
+++ b/include/warp_status.h
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) Meta Platforms, Inc. and affiliates.
+ * SPDX-License-Identifier: MIT
+ *
+ * See LICENSE file in the root directory for Meta's license terms.
+ */
+
+#pragma once
+
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "analysis.h"
+
+enum class WarpStatusKind { LOOPING, BARRIER, PROGRESSING };
+
+struct InstructionInfo {
+  uint64_t pc = 0;
+  std::string mnemonic = "UNKNOWN";
+  bool has_mem = false;
+};
+
+struct WarpStatusEntry {
+  WarpKey key;
+  WarpStatusKind status = WarpStatusKind::PROGRESSING;
+  int loop_period = 0;
+  int repeat_cnt = 0;
+  time_t inactive_secs = 0;
+  time_t last_seen_secs = 0;
+  std::optional<time_t> exit_candidate_secs;
+  std::optional<InstructionInfo> last_instruction;
+  std::vector<InstructionInfo> loop_body;
+};
+
+struct WarpStatusSummary {
+  uint64_t kernel_launch_id = 0;
+  KernelDimensions dims = {};
+  size_t total_warps = 0;
+  size_t finished_warps = 0;
+  size_t active_warps = 0;
+  size_t never_executed = 0;
+  std::set<int> finished_ids;
+  std::set<int> active_ids;
+  std::set<int> never_executed_ids;
+  bool has_stats = false;
+  std::vector<WarpStatusEntry> entries;
+};
+
+WarpStatusSummary collect_warp_status(CTXstate* ctx_state, uint64_t current_kernel_launch_id);
+
+void print_warp_status_text(const WarpStatusSummary& summary);
+
+void write_warp_status_json(const WarpStatusSummary& summary, const std::string& basename);

--- a/src/analysis.cu
+++ b/src/analysis.cu
@@ -28,8 +28,8 @@
 #include "log.h"
 #include "trace_writer.h"
 #include "utils/channel.hpp"
+#include "warp_status.h"
 
-#define PC_HISTORY_LEN 32
 #define LOOP_REPEAT_THRESH 3
 // Throttle interval for hang checks (seconds)
 #define HANG_CHECK_THROTTLE_SECS 1
@@ -60,123 +60,6 @@ static inline uint64_t get_timestamp_ns() {
   auto now = std::chrono::high_resolution_clock::now();
   auto duration = now.time_since_epoch();
   return std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count();
-}
-
-/**
- * Print one instruction line in the exact same format as loop body entries.
- *
- * Purpose:
- * - Provide a single-line renderer that matches the loop body formatting so
- *   different states (looping/barrier/progressing) can share the same
- *   presentation logic for an instruction row.
- *
- * Output format (aligned columns):
- *   Example: [idx] PC <dec>; Offset <dec> [0x<hex>];  <SASS> (has_mem)\n
- * - The trailing "(has_mem)" is printed only when the merged record has
- *   associated memory info.
- * - The index field width is currently fixed to 1 for consistency with our
- *   existing loop body output. Adjust if you later support wider indices.
- *
- * Parameters:
- * - index: The row index to print inside square brackets. For barrier/
- *   progressing single-line outputs, callers typically pass 0.
- * - instr: The merged trace record containing the reg info (and optional mem).
- * - sass_map_for_func: Per-function opcode->SASS map to resolve the mnemonic.
- *   If null or missing entry, prints "UNKNOWN" as fallback.
- * - pc_dec_width: Precomputed decimal width for PC/Offset alignment.
- * - hex_nibbles_max: Precomputed hex width (in nibbles), rounded to multiples
- *   of 4 and clamped to [4,16], used for the 0x... field.
- *
- * Notes:
- * - This function does not perform width computation. Callers should compute
- *   widths across the intended set of rows (entire loop body, or just the last
- *   single record) and pass them here to ensure consistent alignment.
- */
-static inline void print_instruction_line(size_t index, const TraceRecordMerged& instr,
-                                          const std::map<int, std::string>* sass_map_for_func, int pc_dec_width,
-                                          int hex_nibbles_max) {
-  uint64_t pc_val = instr.reg.pc;
-  const char* sass_cstr = "UNKNOWN";
-  if (sass_map_for_func && sass_map_for_func->count(instr.reg.opcode_id)) {
-    sass_cstr = sass_map_for_func->at(instr.reg.opcode_id).c_str();
-  }
-  loprintf("        [%*zu] PC %*lu; Offset %*lu /*0x%0*lx*/;  %s", 1, index, pc_dec_width, (unsigned long)pc_val,
-           pc_dec_width, (unsigned long)pc_val, hex_nibbles_max, (unsigned long)pc_val, sass_cstr);
-  if (instr.has_mem) {
-    loprintf(" (has_mem)");
-  }
-  loprintf("\n");
-}
-
-/**
- * Print the most recent instruction for a warp as a single line (loop-body style).
- *
- * Purpose:
- * - Provide a one-liner for BARRIER/PROGRESSING states that mirrors the loop
- *   body row format for visual consistency with LOOPING output.
- *
- * Behavior:
- * - Fetches the latest entry from the per-warp ring buffer
- *   ((head + filled - 1) % PC_HISTORY_LEN).
- * - Computes widths (decimal/hex) based solely on this last record and prints
- *   a single formatted line prefixed by "last: ".
- * - If there is no available entry (null state or empty), prints a line with
- *   UNKNOWN mnemonic and zero PC/Offset.
- *
- * Parameters:
- * - loop_state: Pointer to the warp's loop state holding the ring buffer.
- * - sass_map_for_func: Per-function opcode->SASS map to resolve the mnemonic.
- *
- * Notes:
- * - This function intentionally recomputes widths for the single last record.
- *   For multi-row loop bodies, prefer computing widths once across all rows and
- *   calling print_instruction_line_like_loop per row.
- */
-static inline void print_last_instruction_line(const WarpLoopState* loop_state,
-                                               const std::map<int, std::string>* sass_map_for_func) {
-  uint64_t last_pc_val = 0;
-  bool last_has_mem = false;
-  const char* last_sass_cstr = "UNKNOWN";
-
-  if (loop_state && loop_state->filled > 0 && sass_map_for_func) {
-    int idx_last = (loop_state->head + (int)loop_state->filled + PC_HISTORY_LEN - 1) % PC_HISTORY_LEN;
-    int opcode_last = loop_state->history[idx_last].reg.opcode_id;
-    last_pc_val = loop_state->history[idx_last].reg.pc;
-    last_has_mem = loop_state->history[idx_last].has_mem;
-    if (sass_map_for_func->count(opcode_last)) {
-      last_sass_cstr = sass_map_for_func->at(opcode_last).c_str();
-    }
-  }
-
-  int pc_dec_width = 1;
-  int hex_nibbles_max = 4;
-  {
-    uint64_t td = last_pc_val;
-    int dec_w = 1;
-    while (td >= 10) {
-      td /= 10;
-      dec_w++;
-    }
-    if (dec_w > pc_dec_width) pc_dec_width = dec_w;
-    int nibbles = 1;
-    if (last_pc_val != 0) {
-      nibbles = 0;
-      uint64_t th = last_pc_val;
-      while (th) {
-        th >>= 4;
-        nibbles++;
-      }
-    }
-    if (nibbles > hex_nibbles_max) hex_nibbles_max = nibbles;
-    hex_nibbles_max = ((hex_nibbles_max + 3) / 4) * 4;
-    if (hex_nibbles_max < 4) hex_nibbles_max = 4;
-    if (hex_nibbles_max > 16) hex_nibbles_max = 16;
-  }
-  loprintf("      Last: [%*d] PC %*lu; Offset %*lu /*0x%0*lx*/;  %s", 1, 0, pc_dec_width, (unsigned long)last_pc_val,
-           pc_dec_width, (unsigned long)last_pc_val, hex_nibbles_max, (unsigned long)last_pc_val, last_sass_cstr);
-  if (last_has_mem) {
-    loprintf(" (has_mem)");
-  }
 }
 
 static inline bool matches_barrier_defer_blocking(const std::string& mnemonic) {
@@ -632,256 +515,30 @@ static void clear_deadlock_state(CTXstate* ctx_state, uint64_t kernel_launch_id 
   }
 }
 
-/**
- * @brief Prints detailed status information for all active warps including loop states.
- *
- * This function provides a comprehensive view of each warp's current state including:
- * - Basic warp identification (CTA coordinates, warp ID)
- * - Loop detection status (whether in loop, loop period, repeat count)
- * - Activity timestamps and exit candidate status
- * - Loop body instruction details if available
- *
- * @param ctx_state Pointer to the state for the current CUDA context
- * @param current_kernel_launch_id The current kernel launch ID for context
- */
 static void print_warp_status_summary(CTXstate* ctx_state, uint64_t current_kernel_launch_id) {
-  time_t now = time(nullptr);
-
-  // Print warp statistics if available
-  if (ctx_state->kernel_warp_tracking.count(current_kernel_launch_id)) {
-    const KernelWarpStats& stats = ctx_state->kernel_warp_tracking[current_kernel_launch_id];
-    size_t total_warps = stats.total_warps;
-    size_t seen_warps = stats.all_seen_warps.size();
-    size_t finished_warps = stats.finished_warps.size();
-    size_t active_warps = ctx_state->active_warps.size();
-
-    // Collect warp IDs in different categories
-    std::set<int> finished_warp_ids;
-    std::set<int> active_warp_ids;
-    std::set<int> never_executed_warp_ids;
-
-    for (const WarpKey& key : stats.finished_warps) {
-      finished_warp_ids.insert(key.warp_id);
-    }
-    for (const WarpKey& key : ctx_state->active_warps) {
-      active_warp_ids.insert(key.warp_id);
-    }
-
-    // Calculate never executed warps (all possible warp IDs minus those we've seen)
-    std::set<int> all_seen_warp_ids;
-    for (const WarpKey& key : stats.all_seen_warps) {
-      all_seen_warp_ids.insert(key.warp_id);
-    }
-
-    // Determine max warp ID based on total warps
-    for (uint32_t wid = 0; wid < total_warps; wid++) {
-      if (all_seen_warp_ids.count(wid) == 0) {
-        never_executed_warp_ids.insert(wid);
-      }
-    }
-
-    size_t never_executed = never_executed_warp_ids.size();
-
-    loprintf("==> WARP STATISTICS for kernel_launch_id=%lu:\n", current_kernel_launch_id);
-    loprintf("    Grid: <%u,%u,%u>, Block: <%u,%u,%u>\n", stats.dimensions.gridDimX, stats.dimensions.gridDimY,
-             stats.dimensions.gridDimZ, stats.dimensions.blockDimX, stats.dimensions.blockDimY,
-             stats.dimensions.blockDimZ);
-    loprintf("\n");
-    loprintf("    Summary:\n");
-    loprintf("      Total warps:           %5zu (100.0%%)\n", total_warps);
-    loprintf("      Finished warps:        %5zu (%5.1f%%)\n", finished_warps,
-             total_warps > 0 ? 100.0 * finished_warps / total_warps : 0.0);
-    loprintf("      Active warps:          %5zu (%5.1f%%)\n", active_warps,
-             total_warps > 0 ? 100.0 * active_warps / total_warps : 0.0);
-    loprintf("      Never executed warps:  %5zu (%5.1f%%)\n", never_executed,
-             total_warps > 0 ? 100.0 * never_executed / total_warps : 0.0);
-
-    // Helper lambda to format ranges from a set of IDs
-    auto format_ranges = [](const std::set<int>& ids) -> std::string {
-      if (ids.empty()) return "none";
-
-      std::string result;
-      auto it = ids.begin();
-      int range_start = *it;
-      int range_end = *it;
-
-      for (++it; it != ids.end(); ++it) {
-        if (*it == range_end + 1) {
-          // Continue current range
-          range_end = *it;
-        } else {
-          // End current range and start new one
-          if (!result.empty()) result += ", ";
-          if (range_start == range_end) {
-            result += std::to_string(range_start);
-          } else {
-            result += std::to_string(range_start) + "-" + std::to_string(range_end);
-          }
-          range_start = range_end = *it;
-        }
-      }
-
-      // Add final range
-      if (!result.empty()) result += ", ";
-      if (range_start == range_end) {
-        result += std::to_string(range_start);
-      } else {
-        result += std::to_string(range_start) + "-" + std::to_string(range_end);
-      }
-
-      return result;
-    };
-
-    loprintf("\n");
-    loprintf("    Warp ID Ranges:\n");
-    loprintf("      Finished:       %s\n", format_ranges(finished_warp_ids).c_str());
-    loprintf("      Active:         %s\n", format_ranges(active_warp_ids).c_str());
-    loprintf("      Never executed: %s\n", format_ranges(never_executed_warp_ids).c_str());
-
-    loprintf("    -----------------------------------------------------------------------\n");
-  }
-
-  if (ctx_state->active_warps.empty()) {
-    loprintf("==> WARP STATUS: No active warps for kernel_launch_id=%lu\n", current_kernel_launch_id);
-    return;
-  }
-
-  loprintf("==> WARP STATUS SUMMARY for kernel_launch_id=%lu (%zu active warps):\n", current_kernel_launch_id,
-           ctx_state->active_warps.size());
-  loprintf("    Format: WarpID[CTA_x,y,z] - LoopStatus - Activity\n");
-  loprintf("    -----------------------------------------------------------------------\n");
-
-  // Resolve SASS map for the current function, if available
-  const std::map<int, std::string>* sass_map_for_func = nullptr;
-  {
-    std::map<uint64_t, std::pair<CUcontext, CUfunction>>::iterator func_iter =
-        kernel_launch_to_func_map.find(current_kernel_launch_id);
+  auto summary = collect_warp_status(ctx_state, current_kernel_launch_id);
+  if (trace_format == 0) {
+    print_warp_status_text(summary);
+  } else {
+    auto func_iter = kernel_launch_to_func_map.find(current_kernel_launch_id);
     if (func_iter != kernel_launch_to_func_map.end()) {
-      CUfunction f_func = func_iter->second.second;
-      if (ctx_state->id_to_sass_map.count(f_func)) {
-        sass_map_for_func = &ctx_state->id_to_sass_map[f_func];
-      }
+      CUcontext ctx = func_iter->second.first;
+      CUfunction func = func_iter->second.second;
+      uint32_t iteration = 0;
+      auto iter_it = kernel_launch_to_iter_map.find(current_kernel_launch_id);
+      if (iter_it != kernel_launch_to_iter_map.end()) iteration = iter_it->second;
+      std::string checksum;
+      auto meta_it = kernel_metadata_by_func.find(func);
+      if (meta_it != kernel_metadata_by_func.end()) checksum = meta_it->second.kernel_checksum;
+      std::string basename = generate_kernel_log_basename(ctx, func, iteration, checksum);
+      write_warp_status_json(summary, basename);
+    } else {
+      loprintf(
+          "WARNING: kernel_launch_id=%lu not found in kernel_launch_to_func_map; skipping JSON warp status output\n",
+          current_kernel_launch_id);
     }
+    print_warp_status_text(summary);
   }
-
-  for (const auto& warp_key : ctx_state->active_warps) {
-    // Basic warp info
-    loprintf("    Warp%d[%d,%d,%d]: ", warp_key.warp_id, warp_key.cta_id_x, warp_key.cta_id_y, warp_key.cta_id_z);
-
-    // Loop state info
-    auto loop_iter = ctx_state->loop_states.find(warp_key);
-    bool is_looping = false;
-    if (loop_iter != ctx_state->loop_states.end()) {
-      const WarpLoopState& loop_state = loop_iter->second;
-      if (loop_state.loop_flag) {
-        is_looping = true;
-        time_t last_seen_secs = 0;
-        auto seen_it2 = ctx_state->last_seen_time_by_warp.find(warp_key);
-        if (seen_it2 != ctx_state->last_seen_time_by_warp.end()) {
-          last_seen_secs = now - seen_it2->second;
-        }
-        loprintf("LOOPING(period=%d, repeat=%d) last_seen=%lds ", loop_state.last_period, loop_state.repeat_cnt,
-                 last_seen_secs);
-      }
-    }
-
-    // Activity info
-    time_t inactive_duration = 0;
-    auto seen_iter = ctx_state->last_seen_time_by_warp.find(warp_key);
-    if (seen_iter != ctx_state->last_seen_time_by_warp.end()) {
-      inactive_duration = now - seen_iter->second;
-    }
-
-    if (!is_looping) {
-      // If not looping, distinguish barrier vs progressing by last_is_defer_blocking_by_warp
-      bool is_barrier = false;
-      auto itBar = ctx_state->last_is_defer_blocking_by_warp.find(warp_key);
-      if (itBar != ctx_state->last_is_defer_blocking_by_warp.end()) {
-        is_barrier = itBar->second;
-      }
-
-      // Use unified single-line printer for last instruction; no temporary variables needed here
-
-      if (is_barrier) {
-        // Barrier category (last observed instruction is BAR.SYNC.DEFER_BLOCKING)
-        // Include inactivity seconds for quick assessment
-        int period_val = 0;
-        int repeat_val = 0;
-        if (loop_iter != ctx_state->loop_states.end()) {
-          period_val = loop_iter->second.last_period;
-          repeat_val = loop_iter->second.repeat_cnt;
-        }
-        loprintf("BARRIER(inactive=%lds) no_loop(period=%d, repeat=%d)\n", inactive_duration, period_val, repeat_val);
-        print_last_instruction_line(loop_iter != ctx_state->loop_states.end() ? &loop_iter->second : nullptr,
-                                    sass_map_for_func);
-      } else {
-        // Progressing category
-        int period_val = 0;
-        int repeat_val = 0;
-        if (loop_iter != ctx_state->loop_states.end()) {
-          period_val = loop_iter->second.last_period;
-          repeat_val = loop_iter->second.repeat_cnt;
-        }
-        loprintf("PROGRESSING no_loop(period=%d, repeat=%d)\n", period_val, repeat_val);
-        print_last_instruction_line(loop_iter != ctx_state->loop_states.end() ? &loop_iter->second : nullptr,
-                                    sass_map_for_func);
-      }
-    }
-
-    // Exit candidate status
-    auto exit_iter = ctx_state->exit_candidate_since_by_warp.find(warp_key);
-    if (exit_iter != ctx_state->exit_candidate_since_by_warp.end()) {
-      time_t exit_duration = now - exit_iter->second;
-      loprintf("- EXIT_CANDIDATE(%lds)", exit_duration);
-    }
-
-    loprintf("\n");
-
-    // Print loop body details if warp is in a confirmed loop
-    if (loop_iter != ctx_state->loop_states.end() && loop_iter->second.loop_flag) {
-      const WarpLoopState& loop_state = loop_iter->second;
-      if (!loop_state.current_loop.instructions.empty()) {
-        loprintf("      Loop Body (%d instructions):\n", loop_state.current_loop.period);
-        // Pre-compute alignment for PC/Offset columns across the loop body
-        int pc_dec_width = 1;
-        int hex_nibbles_max = 4;
-        {
-          size_t upper = std::min(static_cast<size_t>(loop_state.current_loop.period),
-                                  loop_state.current_loop.instructions.size());
-          for (size_t j = 0; j < upper; ++j) {
-            uint64_t pc = loop_state.current_loop.instructions[j].reg.pc;
-            int dec_w = 1;
-            uint64_t td = pc;
-            while (td >= 10) {
-              td /= 10;
-              dec_w++;
-            }
-            if (dec_w > pc_dec_width) pc_dec_width = dec_w;
-            int nibbles = 1;
-            if (pc != 0) {
-              nibbles = 0;
-              uint64_t th = pc;
-              while (th) {
-                th >>= 4;
-                nibbles++;
-              }
-            }
-            if (nibbles > hex_nibbles_max) hex_nibbles_max = nibbles;
-          }
-          hex_nibbles_max = ((hex_nibbles_max + 3) / 4) * 4;
-          if (hex_nibbles_max < 4) hex_nibbles_max = 4;
-          if (hex_nibbles_max > 16) hex_nibbles_max = 16;
-        }
-        for (size_t i = 0;
-             i < static_cast<size_t>(loop_state.current_loop.period) && i < loop_state.current_loop.instructions.size();
-             ++i) {
-          const auto& instr = loop_state.current_loop.instructions[i];
-          print_instruction_line(i, instr, sass_map_for_func, pc_dec_width, hex_nibbles_max);
-        }
-      }
-    }
-  }
-  loprintf("    -----------------------------------------------------------------------\n");
 }
 
 // Checks for potential kernel hangs by determining if all active warps are stuck in loops.

--- a/src/warp_status.cu
+++ b/src/warp_status.cu
@@ -1,0 +1,418 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) Meta Platforms, Inc. and affiliates.
+ * SPDX-License-Identifier: MIT
+ *
+ * See LICENSE file in the root directory for Meta's license terms.
+ */
+
+#include <stdio.h>
+
+#include <map>
+#include <nlohmann/json.hpp>
+#include <set>
+#include <string>
+
+#include "analysis.h"
+#include "env_config.h"
+#include "log.h"
+#include "warp_status.h"
+
+extern std::map<uint64_t, std::pair<CUcontext, CUfunction>> kernel_launch_to_func_map;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+static InstructionInfo make_instruction_info(const TraceRecordMerged& instr,
+                                             const std::map<int, std::string>* sass_map) {
+  InstructionInfo info;
+  info.pc = instr.reg.pc;
+  info.has_mem = instr.has_mem;
+  if (sass_map && sass_map->count(instr.reg.opcode_id)) {
+    info.mnemonic = sass_map->at(instr.reg.opcode_id);
+  }
+  return info;
+}
+
+// Fold a sorted set of integer IDs into compact range strings (e.g., {1,2,3,5} -> {"1-3","5"}).
+// Used by both text and JSON renderers to keep the range-folding rule in one place.
+static std::vector<std::string> build_range_strings(const std::set<int>& ids) {
+  std::vector<std::string> out;
+  if (ids.empty()) return out;
+
+  auto it = ids.begin();
+  int range_start = *it;
+  int range_end = *it;
+
+  auto flush = [&]() {
+    if (range_start == range_end) {
+      out.push_back(std::to_string(range_start));
+    } else {
+      out.push_back(std::to_string(range_start) + "-" + std::to_string(range_end));
+    }
+  };
+
+  for (++it; it != ids.end(); ++it) {
+    if (*it == range_end + 1) {
+      range_end = *it;
+    } else {
+      flush();
+      range_start = range_end = *it;
+    }
+  }
+  flush();
+  return out;
+}
+
+static std::string format_ranges(const std::set<int>& ids) {
+  auto parts = build_range_strings(ids);
+  if (parts.empty()) return "none";
+  std::string result;
+  for (size_t i = 0; i < parts.size(); ++i) {
+    if (i) result += ", ";
+    result += parts[i];
+  }
+  return result;
+}
+
+static nlohmann::json format_ranges_json(const std::set<int>& ids) {
+  using json = nlohmann::json;
+  json arr = json::array();
+  for (const auto& s : build_range_strings(ids)) {
+    arr.push_back(s);
+  }
+  return arr;
+}
+
+// ── collect ──────────────────────────────────────────────────────────────────
+
+WarpStatusSummary collect_warp_status(CTXstate* ctx_state, uint64_t current_kernel_launch_id) {
+  WarpStatusSummary summary;
+  summary.kernel_launch_id = current_kernel_launch_id;
+  time_t now = time(nullptr);
+
+  // Resolve SASS map
+  const std::map<int, std::string>* sass_map = nullptr;
+  {
+    auto func_iter = kernel_launch_to_func_map.find(current_kernel_launch_id);
+    if (func_iter != kernel_launch_to_func_map.end()) {
+      CUfunction f_func = func_iter->second.second;
+      if (ctx_state->id_to_sass_map.count(f_func)) {
+        sass_map = &ctx_state->id_to_sass_map[f_func];
+      }
+    }
+  }
+
+  // Warp statistics
+  if (ctx_state->kernel_warp_tracking.count(current_kernel_launch_id)) {
+    summary.has_stats = true;
+    const KernelWarpStats& stats = ctx_state->kernel_warp_tracking[current_kernel_launch_id];
+    summary.dims = stats.dimensions;
+    summary.total_warps = stats.total_warps;
+    summary.finished_warps = stats.finished_warps.size();
+    summary.active_warps = ctx_state->active_warps.size();
+
+    for (const WarpKey& key : stats.finished_warps) summary.finished_ids.insert(key.warp_id);
+    for (const WarpKey& key : ctx_state->active_warps) summary.active_ids.insert(key.warp_id);
+
+    std::set<int> all_seen;
+    for (const WarpKey& key : stats.all_seen_warps) all_seen.insert(key.warp_id);
+    for (uint32_t wid = 0; wid < stats.total_warps; wid++) {
+      if (all_seen.count(static_cast<int>(wid)) == 0) {
+        summary.never_executed_ids.insert(static_cast<int>(wid));
+      }
+    }
+    summary.never_executed = summary.never_executed_ids.size();
+  }
+
+  // Per-warp entries
+  for (const auto& warp_key : ctx_state->active_warps) {
+    WarpStatusEntry entry;
+    entry.key = warp_key;
+
+    auto loop_iter = ctx_state->loop_states.find(warp_key);
+    bool is_looping = false;
+
+    if (loop_iter != ctx_state->loop_states.end()) {
+      entry.loop_period = loop_iter->second.last_period;
+      entry.repeat_cnt = loop_iter->second.repeat_cnt;
+      if (loop_iter->second.loop_flag) {
+        is_looping = true;
+        entry.status = WarpStatusKind::LOOPING;
+        auto seen_it = ctx_state->last_seen_time_by_warp.find(warp_key);
+        if (seen_it != ctx_state->last_seen_time_by_warp.end()) {
+          entry.last_seen_secs = now - seen_it->second;
+        }
+      }
+    }
+
+    // Inactive duration
+    auto seen_iter = ctx_state->last_seen_time_by_warp.find(warp_key);
+    if (seen_iter != ctx_state->last_seen_time_by_warp.end()) {
+      entry.inactive_secs = now - seen_iter->second;
+    }
+
+    if (!is_looping) {
+      bool is_barrier = false;
+      auto itBar = ctx_state->last_is_defer_blocking_by_warp.find(warp_key);
+      if (itBar != ctx_state->last_is_defer_blocking_by_warp.end()) {
+        is_barrier = itBar->second;
+      }
+      entry.status = is_barrier ? WarpStatusKind::BARRIER : WarpStatusKind::PROGRESSING;
+
+      // Last instruction from ring buffer
+      const WarpLoopState* ls = (loop_iter != ctx_state->loop_states.end()) ? &loop_iter->second : nullptr;
+      if (ls && ls->filled > 0 && sass_map) {
+        int idx_last = (ls->head + (int)ls->filled + PC_HISTORY_LEN - 1) % PC_HISTORY_LEN;
+        entry.last_instruction = make_instruction_info(ls->history[idx_last], sass_map);
+      }
+    }
+
+    // Exit candidate
+    auto exit_iter = ctx_state->exit_candidate_since_by_warp.find(warp_key);
+    if (exit_iter != ctx_state->exit_candidate_since_by_warp.end()) {
+      entry.exit_candidate_secs = static_cast<time_t>(now - exit_iter->second);
+    }
+
+    // Loop body
+    if (is_looping && loop_iter != ctx_state->loop_states.end()) {
+      const WarpLoopState& ls = loop_iter->second;
+      if (!ls.current_loop.instructions.empty()) {
+        size_t upper = std::min(static_cast<size_t>(ls.current_loop.period), ls.current_loop.instructions.size());
+        entry.loop_body.reserve(upper);
+        for (size_t i = 0; i < upper; ++i) {
+          entry.loop_body.push_back(make_instruction_info(ls.current_loop.instructions[i], sass_map));
+        }
+      }
+    }
+
+    summary.entries.push_back(std::move(entry));
+  }
+
+  return summary;
+}
+
+// ── text output ──────────────────────────────────────────────────────────────
+
+static void print_instruction_line(size_t index, const InstructionInfo& info, int pc_dec_width, int hex_nibbles_max) {
+  loprintf("        [%*zu] PC %*lu; Offset %*lu /*0x%0*lx*/;  %s", 1, index, pc_dec_width, (unsigned long)info.pc,
+           pc_dec_width, (unsigned long)info.pc, hex_nibbles_max, (unsigned long)info.pc, info.mnemonic.c_str());
+  if (info.has_mem) {
+    loprintf(" (has_mem)");
+  }
+  loprintf("\n");
+}
+
+static void compute_pc_widths(uint64_t pc, int& pc_dec_width, int& hex_nibbles_max) {
+  int dec_w = 1;
+  uint64_t td = pc;
+  while (td >= 10) {
+    td /= 10;
+    dec_w++;
+  }
+  if (dec_w > pc_dec_width) pc_dec_width = dec_w;
+  int nibbles = 1;
+  if (pc != 0) {
+    nibbles = 0;
+    uint64_t th = pc;
+    while (th) {
+      th >>= 4;
+      nibbles++;
+    }
+  }
+  if (nibbles > hex_nibbles_max) hex_nibbles_max = nibbles;
+}
+
+static void finalize_hex_nibbles(int& hex_nibbles_max) {
+  hex_nibbles_max = ((hex_nibbles_max + 3) / 4) * 4;
+  if (hex_nibbles_max < 4) hex_nibbles_max = 4;
+  if (hex_nibbles_max > 16) hex_nibbles_max = 16;
+}
+
+// Print the "Last: ..." line for a non-looping warp. Shared by BARRIER and PROGRESSING branches.
+static void print_last_instruction_line(const std::optional<InstructionInfo>& last_instruction) {
+  if (last_instruction.has_value()) {
+    const auto& li = last_instruction.value();
+    int pc_dec_width = 1;
+    int hex_nibbles_max = 4;
+    compute_pc_widths(li.pc, pc_dec_width, hex_nibbles_max);
+    finalize_hex_nibbles(hex_nibbles_max);
+    loprintf("      Last: [%*d] PC %*lu; Offset %*lu /*0x%0*lx*/;  %s", 1, 0, pc_dec_width, (unsigned long)li.pc,
+             pc_dec_width, (unsigned long)li.pc, hex_nibbles_max, (unsigned long)li.pc, li.mnemonic.c_str());
+    if (li.has_mem) loprintf(" (has_mem)");
+  } else {
+    loprintf("      Last: [%*d] PC %*lu; Offset %*lu /*0x%0*lx*/;  %s", 1, 0, 1, 0UL, 1, 0UL, 4, 0UL, "UNKNOWN");
+  }
+}
+
+void print_warp_status_text(const WarpStatusSummary& summary) {
+  if (summary.has_stats) {
+    loprintf("==> WARP STATISTICS for kernel_launch_id=%lu:\n", summary.kernel_launch_id);
+    loprintf("    Grid: <%u,%u,%u>, Block: <%u,%u,%u>\n", summary.dims.gridDimX, summary.dims.gridDimY,
+             summary.dims.gridDimZ, summary.dims.blockDimX, summary.dims.blockDimY, summary.dims.blockDimZ);
+    loprintf("\n");
+    loprintf("    Summary:\n");
+    loprintf("      Total warps:           %5zu (100.0%%)\n", summary.total_warps);
+    loprintf("      Finished warps:        %5zu (%5.1f%%)\n", summary.finished_warps,
+             summary.total_warps > 0 ? 100.0 * summary.finished_warps / summary.total_warps : 0.0);
+    loprintf("      Active warps:          %5zu (%5.1f%%)\n", summary.active_warps,
+             summary.total_warps > 0 ? 100.0 * summary.active_warps / summary.total_warps : 0.0);
+    loprintf("      Never executed warps:  %5zu (%5.1f%%)\n", summary.never_executed,
+             summary.total_warps > 0 ? 100.0 * summary.never_executed / summary.total_warps : 0.0);
+
+    loprintf("\n");
+    loprintf("    Warp ID Ranges:\n");
+    loprintf("      Finished:       %s\n", format_ranges(summary.finished_ids).c_str());
+    loprintf("      Active:         %s\n", format_ranges(summary.active_ids).c_str());
+    loprintf("      Never executed: %s\n", format_ranges(summary.never_executed_ids).c_str());
+    loprintf("    -----------------------------------------------------------------------\n");
+  }
+
+  if (summary.entries.empty()) {
+    loprintf("==> WARP STATUS: No active warps for kernel_launch_id=%lu\n", summary.kernel_launch_id);
+    return;
+  }
+
+  loprintf("==> WARP STATUS SUMMARY for kernel_launch_id=%lu (%zu active warps):\n", summary.kernel_launch_id,
+           summary.entries.size());
+  loprintf("    Format: WarpID[CTA_x,y,z] - LoopStatus - Activity\n");
+  loprintf("    -----------------------------------------------------------------------\n");
+
+  for (const auto& entry : summary.entries) {
+    loprintf("    Warp%d[%d,%d,%d]: ", entry.key.warp_id, entry.key.cta_id_x, entry.key.cta_id_y, entry.key.cta_id_z);
+
+    if (entry.status == WarpStatusKind::LOOPING) {
+      loprintf("LOOPING(inactive=%lds, period=%d, repeat=%d) last_seen=%lds ", entry.inactive_secs, entry.loop_period,
+               entry.repeat_cnt, entry.last_seen_secs);
+    } else if (entry.status == WarpStatusKind::BARRIER) {
+      loprintf("BARRIER(inactive=%lds) no_loop(period=%d, repeat=%d)\n", entry.inactive_secs, entry.loop_period,
+               entry.repeat_cnt);
+      print_last_instruction_line(entry.last_instruction);
+    } else {
+      loprintf("PROGRESSING(inactive=%lds) no_loop(period=%d, repeat=%d)\n", entry.inactive_secs, entry.loop_period,
+               entry.repeat_cnt);
+      print_last_instruction_line(entry.last_instruction);
+    }
+
+    if (entry.exit_candidate_secs.has_value()) {
+      loprintf("- EXIT_CANDIDATE(%lds)", entry.exit_candidate_secs.value());
+    }
+
+    loprintf("\n");
+
+    // Loop body
+    if (entry.status == WarpStatusKind::LOOPING && !entry.loop_body.empty()) {
+      loprintf("      Loop Body (%zu instructions):\n", entry.loop_body.size());
+      int pc_dec_width = 1;
+      int hex_nibbles_max = 4;
+      for (const auto& instr : entry.loop_body) {
+        compute_pc_widths(instr.pc, pc_dec_width, hex_nibbles_max);
+      }
+      finalize_hex_nibbles(hex_nibbles_max);
+      for (size_t i = 0; i < entry.loop_body.size(); ++i) {
+        print_instruction_line(i, entry.loop_body[i], pc_dec_width, hex_nibbles_max);
+      }
+    }
+  }
+  loprintf("    -----------------------------------------------------------------------\n");
+}
+
+// ── JSON output ──────────────────────────────────────────────────────────────
+
+static nlohmann::json instruction_to_json(const InstructionInfo& info) {
+  using json = nlohmann::json;
+  json j;
+  j["pc"] = info.pc;
+
+  std::ostringstream hex_oss;
+  hex_oss << "0x" << std::hex << info.pc;
+  j["offset_hex"] = hex_oss.str();
+
+  j["mnemonic"] = info.mnemonic;
+  j["has_mem"] = info.has_mem;
+  return j;
+}
+
+void write_warp_status_json(const WarpStatusSummary& summary, const std::string& basename) {
+  using json = nlohmann::json;
+
+  json root;
+  root["kernel_launch_id"] = summary.kernel_launch_id;
+
+  if (summary.has_stats) {
+    json warp_stats;
+    warp_stats["grid"] = {{"x", summary.dims.gridDimX}, {"y", summary.dims.gridDimY}, {"z", summary.dims.gridDimZ}};
+    warp_stats["block"] = {{"x", summary.dims.blockDimX}, {"y", summary.dims.blockDimY}, {"z", summary.dims.blockDimZ}};
+    warp_stats["summary"] = {
+        {"total_warps", summary.total_warps},
+        {"finished_warps", summary.finished_warps},
+        {"finished_warps_pct", summary.total_warps > 0 ? 100.0 * summary.finished_warps / summary.total_warps : 0.0},
+        {"active_warps", summary.active_warps},
+        {"active_warps_pct", summary.total_warps > 0 ? 100.0 * summary.active_warps / summary.total_warps : 0.0},
+        {"never_executed_warps", summary.never_executed},
+        {"never_executed_warps_pct",
+         summary.total_warps > 0 ? 100.0 * summary.never_executed / summary.total_warps : 0.0}};
+    warp_stats["warp_id_ranges"] = {{"finished", format_ranges_json(summary.finished_ids)},
+                                    {"active", format_ranges_json(summary.active_ids)},
+                                    {"never_executed", format_ranges_json(summary.never_executed_ids)}};
+    root["warp_statistics"] = warp_stats;
+  }
+
+  json warps_array = json::array();
+  for (const auto& entry : summary.entries) {
+    json warp_obj;
+    warp_obj["warp_id"] = entry.key.warp_id;
+    warp_obj["cta"] = {{"x", entry.key.cta_id_x}, {"y", entry.key.cta_id_y}, {"z", entry.key.cta_id_z}};
+
+    const char* status_str = "PROGRESSING";
+    if (entry.status == WarpStatusKind::LOOPING)
+      status_str = "LOOPING";
+    else if (entry.status == WarpStatusKind::BARRIER)
+      status_str = "BARRIER";
+    warp_obj["status"] = status_str;
+
+    warp_obj["loop"] = {{"period", entry.loop_period}, {"repeat", entry.repeat_cnt}};
+    warp_obj["inactive_secs"] = entry.inactive_secs;
+
+    if (entry.status == WarpStatusKind::LOOPING) {
+      warp_obj["last_seen_secs"] = entry.last_seen_secs;
+    }
+
+    if (entry.last_instruction.has_value()) {
+      warp_obj["last_instruction"] = instruction_to_json(entry.last_instruction.value());
+    }
+
+    if (entry.exit_candidate_secs.has_value()) {
+      warp_obj["exit_candidate_secs"] = entry.exit_candidate_secs.value();
+    }
+
+    if (!entry.loop_body.empty()) {
+      json loop_body;
+      loop_body["instruction_count"] = entry.loop_body.size();
+      json instructions = json::array();
+      for (size_t i = 0; i < entry.loop_body.size(); ++i) {
+        json instr_obj = instruction_to_json(entry.loop_body[i]);
+        instr_obj["index"] = i;
+        instructions.push_back(instr_obj);
+      }
+      loop_body["instructions"] = instructions;
+      warp_obj["loop_body"] = loop_body;
+    }
+
+    warps_array.push_back(warp_obj);
+  }
+  root["active_warps"] = warps_array;
+
+  std::string filename = basename + "_warp_status_summary.ndjson";
+
+  // Append one JSON object per snapshot (NDJSON). Multiple invocations for the same
+  // kernel launch (e.g., periodic hang detection) accumulate as separate lines.
+  FILE* fp = fopen(filename.c_str(), "a");
+  if (fp) {
+    std::string json_str = root.dump();
+    fwrite(json_str.c_str(), 1, json_str.size(), fp);
+    fwrite("\n", 1, 1, fp);
+    fclose(fp);
+    loprintf("Warp status JSON appended to %s\n", filename.c_str());
+  } else {
+    loprintf("WARNING: Failed to append warp status JSON to %s\n", filename.c_str());
+  }
+}

--- a/tests/hang_test/test_hang_e2e.py
+++ b/tests/hang_test/test_hang_e2e.py
@@ -1,0 +1,228 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+E2E test: CUTracer hang detection + warp status output.
+
+Runs the hanging Triton kernel from test_hang.py under CUTracer's
+deadlock_detection analysis in two trace formats:
+
+  - Mode 0 (text):   asserts that ``LOOPING(inactive=...)`` appears in the
+                     captured tracer output, guarding the diff that aligned
+                     ``inactive_secs`` rendering across non-BARRIER warps.
+
+  - Mode 2 (NDJSON): asserts that the new
+                     ``<basename>_warp_status_summary.ndjson`` file is created
+                     in append mode (one JSON object per snapshot), and that
+                     the legacy ``_warp_status_summary.json`` is no longer
+                     produced.
+
+Both modes share the expectation that CUTracer terminates the hung subprocess
+with "Deadlock sustained" in its output (non-zero exit code).
+
+This is the Buck equivalent of ``test_hang_test`` /
+``test_hang_test_warp_status_ndjson`` from ``.ci/run_tests.sh``.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import pkg_resources
+from cutracer.runner import _build_cutracer_env, resolve_cutracer_so
+
+
+class TestHangE2E(unittest.TestCase):
+    """E2E: CUTracer hang detection and warp status snapshot output."""
+
+    @classmethod
+    def setUpClass(cls):
+        # CUDA_INJECTION64_PATH must be unset before resolve_cutracer_so()
+        # picks the bundled .so; an externally-set value triggers a hard error.
+        os.environ.pop("CUDA_INJECTION64_PATH", None)
+
+        cls.cutracer_so = resolve_cutracer_so()
+
+        # Extract the hanging kernel script from bundled resources
+        script_content = pkg_resources.resource_string(
+            "hang_test_resources",
+            "test_hang.py",
+        ).decode()
+        tmp = tempfile.NamedTemporaryFile(
+            suffix=".py", mode="w", delete=False, prefix="hang_"
+        )
+        tmp.write(script_content)
+        tmp.flush()
+        tmp.close()
+        cls.script_path = tmp.name
+
+        # Temp dir for CUTracer trace + warp-status output
+        cls.trace_dir = tempfile.mkdtemp(prefix="cutracer_hang_")
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "script_path") and os.path.exists(cls.script_path):
+            os.unlink(cls.script_path)
+        if hasattr(cls, "trace_dir") and os.path.exists(cls.trace_dir):
+            shutil.rmtree(cls.trace_dir, ignore_errors=True)
+
+    def _clean_trace_dir(self):
+        for f in Path(self.trace_dir).iterdir():
+            if f.is_file():
+                f.unlink()
+
+    def _run_hang(self, trace_format: int) -> subprocess.CompletedProcess:
+        """Run test_hang.py under CUTracer with deadlock_detection.
+
+        The kernel hangs intentionally; CUTracer is expected to detect the
+        deadlock and terminate the subprocess (non-zero exit code).
+        """
+        self._clean_trace_dir()
+
+        env = _build_cutracer_env(
+            cutracer_so=self.cutracer_so,
+            instrument=None,  # deadlock_detection auto-adds reg_trace
+            analysis="deadlock_detection",
+            kernel_filters="add_kernel",
+            instr_categories=None,
+            trace_format=str(trace_format),
+            output_dir=self.trace_dir,
+            verbose=None,
+            zstd_level=None,
+            delay_ns=None,
+        )
+
+        # Hard wall-clock timeout: hang detection should kick in well before
+        # this fires; if it doesn't, the test should fail loudly rather than
+        # hang the test runner.
+        return subprocess.run(
+            [sys.executable, self.script_path],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+    @staticmethod
+    def _captured_output(result: subprocess.CompletedProcess) -> str:
+        return (result.stdout or "") + (result.stderr or "")
+
+    def _assert_deadlock_detected(self, result: subprocess.CompletedProcess):
+        """Common precondition: CUTracer terminated the process on hang."""
+        output = self._captured_output(result)
+        self.assertNotEqual(
+            result.returncode,
+            0,
+            f"Expected hang detection to terminate subprocess, but it exited 0.\n"
+            f"OUTPUT:\n{output[-4000:]}",
+        )
+        self.assertIn(
+            "Deadlock sustained",
+            output,
+            f"Hang detection message not found in subprocess output.\n"
+            f"OUTPUT:\n{output[-4000:]}",
+        )
+
+    # ------------------------------------------------------------------
+    # Test: text mode prints inactive=Xs for LOOPING entries
+    # ------------------------------------------------------------------
+
+    def test_text_mode_inactive_secs(self):
+        """Mode 0: LOOPING warps must include ``inactive=Xs`` in text output.
+
+        Regression guard for the diff that made ``inactive_secs`` render for
+        all warp states (not just BARRIER) so text and JSON outputs agree.
+        """
+        result = self._run_hang(trace_format=0)
+        self._assert_deadlock_detected(result)
+
+        output = self._captured_output(result)
+        self.assertIn(
+            "LOOPING(inactive=",
+            output,
+            "Expected 'LOOPING(inactive=...' line in text-mode warp status "
+            "summary; the hanging kernel should produce LOOPING warps and "
+            "the renderer must include inactive_secs for them.",
+        )
+
+    # ------------------------------------------------------------------
+    # Test: NDJSON warp status appends one JSON object per snapshot
+    # ------------------------------------------------------------------
+
+    def test_ndjson_mode_warp_status(self):
+        """Mode 2: warp status is appended as NDJSON across snapshots.
+
+        Validates the diff that switched ``write_warp_status_json`` from a
+        truncating ``.json`` to an append-mode ``.ndjson`` so multiple
+        hang-detection ticks accumulate as separate lines instead of
+        overwriting each other.
+        """
+        result = self._run_hang(trace_format=2)
+        self._assert_deadlock_detected(result)
+
+        # Legacy single-file output must no longer be produced
+        legacy_files = sorted(Path(self.trace_dir).glob("*_warp_status_summary.json"))
+        self.assertEqual(
+            legacy_files,
+            [],
+            f"Legacy *_warp_status_summary.json should no longer be written, "
+            f"found: {legacy_files}",
+        )
+
+        ndjson_files = sorted(Path(self.trace_dir).glob("*_warp_status_summary.ndjson"))
+        self.assertGreater(
+            len(ndjson_files),
+            0,
+            f"No *_warp_status_summary.ndjson produced in {self.trace_dir}.\n"
+            f"Directory contents: {sorted(p.name for p in Path(self.trace_dir).iterdir())}",
+        )
+
+        ndjson_path = ndjson_files[0]
+        lines = [
+            ln.strip() for ln in ndjson_path.read_text().splitlines() if ln.strip()
+        ]
+        self.assertGreater(
+            len(lines),
+            0,
+            f"NDJSON warp status file is empty: {ndjson_path}",
+        )
+
+        records = []
+        for i, line in enumerate(lines):
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError as e:
+                self.fail(
+                    f"{ndjson_path.name} line {i + 1} is not valid JSON: {e}\n"
+                    f"line content: {line[:200]}"
+                )
+
+        # All snapshots in one file must come from the same kernel launch
+        kernel_ids = {r.get("kernel_launch_id") for r in records}
+        self.assertEqual(
+            len(kernel_ids),
+            1,
+            f"Expected all snapshots to share kernel_launch_id, got: {kernel_ids}",
+        )
+
+        # Every warp entry must carry inactive_secs (consistency with text)
+        # and at least one entry across all snapshots must be LOOPING.
+        saw_looping = False
+        for record in records:
+            for warp in record.get("active_warps", []):
+                self.assertIn(
+                    "inactive_secs",
+                    warp,
+                    f"warp entry missing inactive_secs: {warp}",
+                )
+                if warp.get("status") == "LOOPING":
+                    saw_looping = True
+        self.assertTrue(
+            saw_looping,
+            "Expected at least one LOOPING warp entry across snapshots; "
+            "the hanging kernel should be detected as LOOPING.",
+        )


### PR DESCRIPTION
Summary:
Add E2E coverage for the warp status output changes in D102673276:

- .ci/run_tests.sh:
  - extend test_hang_test() to assert LOOPING(inactive=...) appears in
    text-mode output (regression guard for inactive_secs alignment).
  - add test_hang_test_warp_status_ndjson() that runs the same hanging
    kernel with CUTRACER_TRACE_FORMAT=2 and validates the new
    <basename>_warp_status_summary.ndjson append-mode file: every line
    is valid JSON, kernel_launch_id is consistent across snapshots,
    every warp entry has inactive_secs, and at least one warp is
    LOOPING. Also asserts the legacy *_warp_status_summary.json is
    no longer produced.
  - wire the new function into run_all_tests and the case dispatcher
    (TEST_TYPE=hang-ndjson).

- tests/hang_test/{BUCK,test_hang_e2e.py}: buck-side
  python_unittest_remote_gpu mirroring the same checks for fbcode CI /
  TPX. Bundles test_hang.py as a resource and runs it under cutracer
  in two trace formats with the same assertions as the shell harness.

Differential Revision: D102697046


