### PR TITLE
Replace install-triton.sh with Triton-Nightly matrix leg

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -1337,6 +1337,12 @@ run_all_tests() {
     failed_suites+=("mem-value-trace")
   fi
 
+  if test_proton; then
+    passed_suites+=("proton")
+  else
+    failed_suites+=("proton")
+  fi
+
   # Re-enable set -e
   set -e
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,8 +60,24 @@ jobs:
   build-and-test:
     runs-on: 4-core-ubuntu-gpu-t4
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        triton: [default, nightly]
+    # The `nightly` leg installs upstream Triton main (via OpenAI's
+    # Triton-Nightly feed), which can drift out of ABI sync with the
+    # `triton` commit pinned by the current PyTorch nightly. Treat it as
+    # a canary: surface the failure in the PR check list, but don't
+    # block merges on it. The `default` leg remains required.
+    continue-on-error: ${{ matrix.triton == 'nightly' }}
     env:
       DEBUG: "0"
+      CONDA_ENV: "cutracer-${{ matrix.triton }}"
+      # OpenAI-published Triton nightly wheel feed. The package is `triton`,
+      # built from triton-lang/triton main; versions look like
+      # 3.7.0+gitXXXXXXXX (commit-pinned, reproducible). Used only by the
+      # `nightly` matrix leg.
+      TRITON_NIGHTLY_INDEX_URL: "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/simple/"
 
     steps:
       - name: Checkout repository
@@ -74,6 +90,18 @@ jobs:
           CUDA_VERSION: "12.8"
         run: |
           bash .ci/setup.sh
+      - name: Install Triton nightly
+        if: matrix.triton == 'nightly'
+        run: |
+          source /opt/miniconda3/etc/profile.d/conda.sh
+          conda activate "$CONDA_ENV"
+          # PyTorch nightly bundles `pytorch-triton`, which conflicts with
+          # the upstream `triton` package (both register `import triton`).
+          # Remove both before installing the nightly to avoid a
+          # half-overwritten install.
+          python -m pip uninstall -y pytorch-triton triton 2>/dev/null || true
+          python -m pip install -U --pre triton --extra-index-url "${TRITON_NIGHTLY_INDEX_URL}"
+          python -c "import triton; print(f'Triton: {triton.__version__} from {triton.__file__}')"
       - name: Run tests
         env:
           TEST_TYPE: ${{ github.event.inputs.test-type || 'all' }}
@@ -85,7 +113,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: test-artifacts-cuda12.8-debug0
+          name: test-artifacts-cuda12.8-debug0-${{ matrix.triton }}
           path: |
             tests/vectoradd/*.sass
             tests/vectoradd/*.log
@@ -98,52 +126,17 @@ jobs:
             tests/py_add/mode*_validation.log
             tests/py_add/mode*_run.log
             tests/py_add/mode1_decompressed.ndjson
-  test-triton-source:
-    runs-on: 4-core-ubuntu-gpu-t4
-    timeout-minutes: 60
-    env:
-      DEBUG: "0"
-      CONDA_ENV: "cutracer-triton-source"
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - name: Setup environment
-        env:
-          CUDA_VERSION: "12.8"
-        run: |
-          bash .ci/setup.sh
-      - name: Install Triton from source
-        run: |
-          wget https://raw.githubusercontent.com/meta-pytorch/tritonparse/refs/heads/main/.ci/install-triton.sh -O /tmp/install-triton.sh
-          bash /tmp/install-triton.sh
-      - name: Run tests
-        env:
-          TEST_TYPE: proton
-          TIMEOUT: 60
-          INSTALL_THIRD_PARTY: 1
-        run: |
-          bash .ci/run_tests.sh
-      - name: Upload test artifacts
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: test-artifacts-triton-cuda12.8-debug0
-          path: |
             tests/proton_tests/*.log
             tests/proton_tests/*.sass
             tests/proton_tests/*.csv
   check-status:
     runs-on: ubuntu-latest
-    needs: [build-and-test, test-triton-source]
+    needs: [build-and-test]
     if: always()
     steps:
       - name: Check test results
         run: |
-          if [ "${{ needs.build-and-test.result }}" = "success" ] && [ "${{ needs.test-triton-source.result }}" = "success" ]; then
+          if [ "${{ needs.build-and-test.result }}" = "success" ]; then
               echo "✅ All tests passed!"
           else
               echo "❌ Some tests failed!"

--- a/docs/Build-Test-and-CI.md
+++ b/docs/Build-Test-and-CI.md
@@ -69,9 +69,8 @@ changes do not trigger a full build/test cycle.
 | Job | Runner | What it does |
 |-----|--------|--------------|
 | `format-check` | `ubuntu-latest` | Installs `clang-format==21.1.2` and the Python dev extras, then runs `./format.sh check` |
-| `build-and-test` | `4-core-ubuntu-gpu-t4` | Builds CUTracer via `bash .ci/setup.sh` (CUDA 12.8) and runs the test suite via `bash .ci/run_tests.sh` (`TEST_TYPE=all`, `TIMEOUT=60`, `INSTALL_THIRD_PARTY=1`). Artifacts: vectoradd, py_add logs/traces |
-| `test-triton-source` | `4-core-ubuntu-gpu-t4` | Same setup, but installs Triton from source (via TritonParse's `install-triton.sh`) and runs `TEST_TYPE=proton`. Artifacts: proton_tests logs/SASS/CSV |
-| `check-status` | `ubuntu-latest` | Aggregates `build-and-test` + `test-triton-source` results and fails the workflow if either failed |
+| `build-and-test (default)` / `build-and-test (nightly)` | `4-core-ubuntu-gpu-t4` | Matrix job over `triton: [default, nightly]`. Both legs build CUTracer via `bash .ci/setup.sh` (CUDA 12.8) and run the full suite via `bash .ci/run_tests.sh` (`TEST_TYPE=all`, `TIMEOUT=60`, `INSTALL_THIRD_PARTY=1`). The `nightly` leg first replaces PyTorch nightly's bundled `pytorch-triton` with the upstream `Triton-Nightly` wheel from OpenAI's Azure DevOps feed; it carries `continue-on-error: true` and is treated as a canary, since upstream Triton main can ABI-drift from the commit PyTorch nightly pins. Artifacts (per leg): vectoradd, py_add, proton_tests logs/traces |
+| `check-status` | `ubuntu-latest` | Aggregates the matrix `build-and-test` results. Fails the workflow if the required `default` leg failed; the `nightly` leg is non-blocking (canary) |
 
 The `workflow_dispatch` trigger also exposes `test-type` (`all` /
 `build-only` / `vectoradd`) and `debug` (boolean) inputs for ad-hoc runs.


### PR DESCRIPTION
Summary:
The `test-triton-source` CI job was wgetting `install-triton.sh` from `meta-pytorch/tritonparse@main` and running it to build Triton from source. As of the latest tritonparse `main`, that script's conda-discovery branch (`command -v conda` → `conda info --base`) resolves to the GitHub-hosted runner's preinstalled conda (e.g. `/usr/share/miniconda3`) instead of the `/opt/miniconda3` set up by `.ci/setup.sh`, so `conda activate cutracer-triton-source` fails with `EnvironmentNameNotFound`. The `/opt/miniconda3` fallback in the script is dead code on hosted runners. Tritonparse's own CI no longer invokes this script (see `tritonparse/.ci/README.md`), so the regression went unnoticed upstream.

Refactor the two-job layout into a single `build-and-test` job with a `triton: [default, nightly]` matrix axis. Both legs run identical setup, identical `TEST_TYPE=all`, and upload identical artifact paths; the only difference is one extra step on the `nightly` leg that replaces PyTorch nightly's bundled `pytorch-triton` with the upstream `triton` wheel from OpenAI's `Triton-Nightly` Azure DevOps feed (the same feed tritonparse migrated to). This eliminates the conda-discovery bug entirely, drops a 30-50 minute source build to a few-second `pip install`, removes the dependency on a third-party install script that upstream maintainers no longer exercise, and makes "default vs nightly Triton" structurally one axis of one job instead of two manually-kept-in-sync jobs.

`run_all_tests` in `.ci/run_tests.sh` previously omitted `test_proton`; it is now invoked alongside the other suites so both matrix legs cover proton (which was the entire reason the second job existed). `check-status` simplifies to `needs: [build-and-test]` since matrix results roll up automatically. `docs/Build-Test-and-CI.md` is updated to match.

Differential Revision: D103725549


