### PR TITLE
Force inductor inline compile in test_add.py to dodge upstream-Triton subproc-pool driver crash

### DIFF
--- a/tests/py_add/test_add.py
+++ b/tests/py_add/test_add.py
@@ -8,6 +8,22 @@ enabling reliable cross-format validation (Mode 0/1/2 comparison).
 """
 
 import torch
+import torch._inductor.config as inductor_config
+
+# Force inductor to compile inline in the main process. The default path routes
+# Triton compilation through inductor's compile-worker SubprocPool, whose
+# workers are forked after a CUDA-touching pre_fork_setup(). With upstream
+# NVIDIA Triton 3.7.0+, the forked child's cuInit returns
+# CUDA_ERROR_NOT_INITIALIZED and Triton's `_create_driver` raises
+# `RuntimeError: 0 active drivers ([])` — observed in the test.yml `nightly`
+# leg (cu128) and expected in the test-h100.yml `triton-nightly` lane (cu130).
+#
+# Setting only TORCHINDUCTOR_COMPILE_THREADS=1 is not enough: the env var is
+# read once via decide_compile_threads() and cached on inductor_config, so any
+# earlier inductor touch in the same process would make it a no-op. Override
+# the config attribute directly. Same root-cause + fix shape as D105902628 in
+# tritonparse.
+inductor_config.compile_threads = 1
 
 
 @torch.compile


### PR DESCRIPTION
Summary:
The `nightly` matrix leg of `.github/workflows/test.yml` is failing in `test_py_add_with_kernel_filters` with:

  torch._inductor.exc.InductorError: SubprocException
    ... subproc_pool.py:457, in do_job
    ... triton/runtime/driver.py:20, in _create_driver
  RuntimeError: 0 active drivers ([]). There should only be one.

Trigger: `tests/py_add/test_add.py` calls `simple_add(a, b)` (a `torch.compile` decorated function). The first call enters inductor, which fans Triton kernel compilation out to its `SubprocPool` of compile workers. The pool forks workers after a `pre_fork_setup()` that has already touched CUDA; in the forked child, upstream NVIDIA Triton 3.7.0+ sees `cuInit` return `CUDA_ERROR_NOT_INITIALIZED` and `_create_driver` raises the "0 active drivers" error above.

Fix: compile inline in the main process by overriding `torch._inductor.config.compile_threads = 1` before the first `simple_add()` call. This bypasses `SubprocPool` entirely — no fork, no broken CUDA child driver init. Setting only `TORCHINDUCTOR_COMPILE_THREADS=1` would be insufficient: the env var is read once via `decide_compile_threads()` and then cached on `inductor_config.compile_threads`, so any earlier inductor touch in the same process would make the env var a no-op. Overriding the config attribute directly is robust regardless of test ordering.

This is the same root cause and fix shape as D105902628 in tritonparse. CUTracer's CI log proves the bug is not cu130-specific: the `test.yml nightly` leg here runs on cu128 + upstream Triton `3.7.0+git40e899b0` and reproduces the exact same `subproc_pool.py:457` → `RuntimeError: 0 active drivers ([])` stack. The `test-h100.yml triton-nightly` lane (cu130 + upstream Triton main) is expected to be equally affected.

Scope note: `test_add.py` is only run via fresh subprocesses (from `.ci/run_tests.sh`'s `test_trace_formats` / `test_py_add_with_kernel_filters` and from `tests/py_add/test_py_add_e2e.py:_run_py_add`). All call sites benefit from this single in-script override — no CI-script changes needed.

Differential Revision: D106516611


