### PR TITLE
install_third_party.sh: download rapidjson headers (fix OSS CI) (#224)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ nvbit_release/
 *.log
 third_party/nvbit
 third_party/nlohmann
+third_party/rapidjson
 
 tests/vectoradd/vectoradd
 tests/vectoradd_smem/vectoradd_smem

--- a/install_third_party.sh
+++ b/install_third_party.sh
@@ -4,8 +4,9 @@
 # Script to download and install third-party dependencies for CUTracer
 #
 # Environment Variables:
-#   NVBIT_VERSION  - NVBit version (or "latest" for latest release)
-#   JSON_VERSION   - nlohmann/json version
+#   NVBIT_VERSION       - NVBit version (or "latest" for latest release)
+#   JSON_VERSION        - nlohmann/json version
+#   RAPIDJSON_VERSION   - rapidjson release tag (header-only)
 #
 # Usage:
 #   ./install_third_party.sh                        # Use defaults
@@ -17,6 +18,7 @@
 # ============================================================
 NVBIT_VERSION="${NVBIT_VERSION:-1.8}"
 JSON_VERSION="${JSON_VERSION:-3.12.0}"
+RAPIDJSON_VERSION="${RAPIDJSON_VERSION:-1.1.0}"
 
 # ============================================================
 # Install NVBit
@@ -144,6 +146,48 @@ else
     echo "Error: Failed to download nlohmann/json."
     exit 1
 fi
+
+# ============================================================
+# Install rapidjson (header-only)
+# ============================================================
+echo ""
+echo "Downloading rapidjson ${RAPIDJSON_VERSION}..."
+RAPIDJSON_URL="https://github.com/Tencent/rapidjson/archive/refs/tags/v${RAPIDJSON_VERSION}.tar.gz"
+TEMP_FILE=$(mktemp)
+curl -L -o "$TEMP_FILE" "$RAPIDJSON_URL"
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to download rapidjson."
+    rm -f "$TEMP_FILE"
+    exit 1
+fi
+
+TEMP_DIR=$(mktemp -d)
+tar -xzf "$TEMP_FILE" -C "$TEMP_DIR"
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to extract rapidjson."
+    rm -f "$TEMP_FILE"
+    rm -rf "$TEMP_DIR"
+    exit 1
+fi
+
+# rapidjson tarball layout: rapidjson-<version>/include/rapidjson/*.h
+RAPIDJSON_TOP=$(find "$TEMP_DIR" -mindepth 1 -maxdepth 1 -type d -name 'rapidjson-*' | head -1)
+RAPIDJSON_EXTRACTED="$RAPIDJSON_TOP/include/rapidjson"
+if [ -z "$RAPIDJSON_TOP" ] || [ ! -d "$RAPIDJSON_EXTRACTED" ]; then
+    echo "Error: Unable to find rapidjson headers in extracted archive."
+    rm -f "$TEMP_FILE"
+    rm -rf "$TEMP_DIR"
+    exit 1
+fi
+
+# Install headers to third_party/rapidjson so '#include <rapidjson/*.h>' resolves
+# via the existing '-I./third_party' include path in the Makefile.
+rm -rf third_party/rapidjson
+mv "$RAPIDJSON_EXTRACTED" third_party/rapidjson
+rm -f "$TEMP_FILE"
+rm -rf "$TEMP_DIR"
+
+echo "rapidjson ${RAPIDJSON_VERSION} has been successfully installed."
 
 echo ""
 echo "All third-party dependencies have been successfully installed."


### PR DESCRIPTION
Summary:

The rapidjson migration (D-stack landed 2026-06-03, ending at `f762ff8d` "TraceWriter: make rapidjson the default and remove the nlohmann hot path") added `src/trace_rapidjson.cpp`, which `#include <rapidjson/stringbuffer.h>` and `<rapidjson/writer.h>`. Internally these resolve via the Buck dep `fbsource//third-party/rapidjson:rapidjson`, but the OSS GitHub-Actions build uses `make` with `-I./third_party` and pulls third-party deps from `install_third_party.sh` — which only knew about NVBit and `nlohmann/json`. The `facebookexperimental/CUTracer` `build-and-test (default)` job has been failing since the migration landed:

```
src/trace_rapidjson.cpp:18:10: fatal error: rapidjson/stringbuffer.h: No such file or directory
make: *** [Makefile:170: obj/trace_rapidjson.o] Error 1
```

This diff extends `install_third_party.sh` to also fetch rapidjson `v1.1.0` (header-only) from the upstream Tencent/rapidjson release tarball and stage it at `third_party/rapidjson/*.h`, matching the existing `-I./third_party` include search path used by the Makefile. Version is pinned via `RAPIDJSON_VERSION` env var, following the same pattern as `NVBIT_VERSION` / `JSON_VERSION`. `trace_rapidjson.cpp` only touches `StringBuffer` and `Writer<>`, both stable since 1.0.x, so the v1.1.0 release tag is sufficient.

Verified locally: smoke-tested the download/extract path, the resulting `third_party/rapidjson/{stringbuffer,writer}.h` exist, and `g++ -std=c++17 -I./third_party -fsyntax-only` on the affected `#include`s succeeds.

Differential Revision: D107965035


