### PR TITLE
Add conv_bwd_weight illegal-memory-access debugging example (#227)

### DIFF
--- a/examples/conv_bwd_weight_ima/README.md
+++ b/examples/conv_bwd_weight_ima/README.md
@@ -1,0 +1,109 @@
+# Example: Root-causing an illegal memory access with CUTracer
+
+This example shows how CUTracer was used to localize a GPU illegal memory
+access (IMA) down to a single SASS instruction and trace the bad address back
+to its source registers -- pinning the bug on `ptxas` rather than Triton or
+LLVM.
+
+Upstream issue: pytorch/pytorch#187081.
+
+## Background
+
+A TorchInductor-generated Triton kernel, `triton_convolution2d_bwd_weight`,
+reads ~17 GB out of bounds on Blackwell (sm100, GB200/B200), crashing a conv
+backward test. `mini_repro_bwd_weight.py` is the distilled standalone kernel
+(torch + triton only) for the single failing autotune config
+(`BLOCK_M=256, BLOCK_N=16, BLOCK_K=16, num_warps=4, num_stages=2`).
+
+A subtlety that makes this a good CUTracer example: CUTracer (NVBit) forces
+`CUDA_MANAGED_FORCE_DEVICE_ALLOC=1`, so the OOB address lands in a mapped
+managed region and the process does **not** hard-crash under CUTracer. The
+buggy load still executes, so `mem_addr_trace` and `reg_trace` still capture
+the out-of-bounds address and its provenance -- which is exactly how the bug
+was localized without needing the crash.
+
+## Environment
+
+The bug is version-specific (it lives in `ptxas`), so the exact toolchain
+matters when reproducing or reporting it.
+
+| Component | Version |
+|-----------|---------|
+| GPU | NVIDIA GB200 (Blackwell, sm100, compute cap 10.0) |
+| NVIDIA driver | 580.82.07 |
+| `ptxas` (CUDA toolkit) | release 13.0, V13.0.88 |
+| `cuobjdump` / `nvdisasm` | CUDA 13.0 |
+| PyTorch | 2.13.0.dev20260611+cu130 (nightly) |
+| Triton | 3.7.1 |
+| Python | 3.14.4 |
+| `compute-sanitizer` | CUDA 13.0 |
+
+## Source kernel
+
+`mini_repro_bwd_weight.py` -- the masked `X` load
+`matrix_x = tl.load(x_ptrs, mask=mask_x)` faults at SASS offset `+0x2120`.
+
+| Parameter   | Value |
+|-------------|-------|
+| BLOCK_M     | 256   |
+| BLOCK_N     | 16    |
+| BLOCK_K     | 16    |
+| num_warps   | 4     |
+| num_stages  | 2     |
+| Grid        | 1,1,1 |
+| Block       | 128,1,1 |
+
+## Root cause
+
+PTX masks the load correctly via the `cp.async` `src-size` operand (`= 0` on
+the masked path), which per the PTX ISA must not access the source address.
+`ptxas` lowers it to a predicated `LDGSTS` that *does* dereference the address,
+and miscomputes the 64-bit address high word, so a should-be-masked lane reads
+out of bounds. Confirmed `ptxas`: `DISABLE_PTXAS_OPT=1` on the same PTX gives
+0 sanitizer errors and correct numerics. See `example_ptx_vs_sass.txt`.
+
+## How to reproduce
+
+Plain run (no CUTracer) -- hard crash:
+
+```bash
+python mini_repro_bwd_weight.py
+# RuntimeError: Triton Error [CUDA]: an illegal memory access was encountered
+```
+
+Confirm it is a ptxas optimizer bug (same PTX, optimizer off -> clean):
+
+```bash
+DISABLE_PTXAS_OPT=1 compute-sanitizer --tool memcheck python mini_repro_bwd_weight.py
+# ERROR SUMMARY: 0 errors
+```
+
+Capture the per-lane OOB addresses at the faulting load with CUTracer
+(`mem_addr_trace`):
+
+```bash
+buck2 run //triton/tools/CUTracer:cutracer -c fbcode.nvcc_arch=b200a -- trace \
+    --instrument mem_addr_trace \
+    --kernel-filters triton_convolution2d_bwd_weight \
+    --output-dir /tmp/ct_mem \
+    -- python mini_repro_bwd_weight.py
+```
+
+Trace the bad address back to its source registers (`reg_trace`):
+
+```bash
+buck2 run //triton/tools/CUTracer:cutracer -c fbcode.nvcc_arch=b200a -- trace \
+    --instrument reg_trace \
+    --kernel-filters triton_convolution2d_bwd_weight \
+    --output-dir /tmp/ct_reg \
+    -- python mini_repro_bwd_weight.py
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `mini_repro_bwd_weight.py` | Standalone reproducer (torch + triton only). |
+| `example_mem_addr_excerpt.txt` | `mem_addr_trace` excerpt: the 32 lane addresses at `pc=0x2120` for thread (0,0,0), showing the ~17 GB OOB read. |
+| `example_reg_trace_excerpt.txt` | `reg_trace` excerpt: register-by-register provenance of the bad address (negative halo index `R35=-16`, corrupted high word `R21=0xfffa`). |
+| `example_ptx_vs_sass.txt` | The PTX `cp.async` masking (`src-size=0`) vs the miscompiled SASS `LDGSTS`. |

--- a/examples/conv_bwd_weight_ima/example_mem_addr_excerpt.txt
+++ b/examples/conv_bwd_weight_ima/example_mem_addr_excerpt.txt
@@ -1,0 +1,70 @@
+pc=0x2120  warp=0  cta=(0,0,0)  -- SASS: LDGSTS.E [R73+0x400], desc[UR6][R20.64], P6  (masked cp.async X load)
+records at this pc (loop iterations): 82
+
+== ITER with OOB addresses (thread0 reads ~17GB past allocation) ==
+  lane 0 (thread 0): 0xfffd01c00f3c
+  lane 1 (thread 1): 0xfffd01c0133c
+  lane 2 (thread 2): 0xfffd01c0173c
+  lane 3 (thread 3): 0xfffd01c01b3c
+  lane 4 (thread 4): 0xfffd01c01f3c
+  lane 5 (thread 5): 0xfffd01c0233c
+  lane 6 (thread 6): 0xfffd01c0273c
+  lane 7 (thread 7): 0xfffd01c02b3c
+  lane 8 (thread 8): 0xfffd01c02f3c
+  lane 9 (thread 9): 0xfffd01c0333c
+  lane10 (thread 10): 0xfffd01c0373c
+  lane11 (thread 11): 0xfffd01c03b3c
+  lane12 (thread 12): 0xfffd01c03f3c
+  lane13 (thread 13): 0xfffd01c0433c
+  lane14 (thread 14): 0xfffd01c0473c
+  lane15 (thread 15): 0xfffd01c04b3c
+  lane16 (thread 16): 0xfffd01c04f3c
+  lane17 (thread 17): 0xfffd01c0533c
+  lane18 (thread 18): 0xfffd01c0573c
+  lane19 (thread 19): 0xfffd01c05b3c
+  lane20 (thread 20): 0xfffd01c05f3c
+  lane21 (thread 21): 0xfffd01c0633c
+  lane22 (thread 22): 0xfffd01c0673c
+  lane23 (thread 23): 0xfffd01c06b3c
+  lane24 (thread 24): 0xfffd01c06f3c
+  lane25 (thread 25): 0xfffd01c0733c
+  lane26 (thread 26): 0xfffd01c0773c
+  lane27 (thread 27): 0xfffd01c07b3c
+  lane28 (thread 28): 0xfffd01c07f3c
+  lane29 (thread 29): 0xfffd01c0833c
+  lane30 (thread 30): 0xfffd01c0873c
+  lane31 (thread 31): 0xfffd01c08b3c
+
+== ITER with small/base addresses (masked->base region) ==
+  lane 0 (thread 0): 0x000000000800
+  lane 1 (thread 1): 0x000000000804
+  lane 2 (thread 2): 0x000000000808
+  lane 3 (thread 3): 0x00000000080c
+  lane 4 (thread 4): 0x000000000810
+  lane 5 (thread 5): 0x000000000814
+  lane 6 (thread 6): 0x000000000818
+  lane 7 (thread 7): 0x00000000081c
+  lane 8 (thread 8): 0x000000000820
+  lane 9 (thread 9): 0x000000000824
+  lane10 (thread 10): 0x000000000828
+  lane11 (thread 11): 0x00000000082c
+  lane12 (thread 12): 0x000000000830
+  lane13 (thread 13): 0x000000000834
+  lane14 (thread 14): 0x000000000838
+  lane15 (thread 15): 0x00000000083c
+  lane16 (thread 16): 0x000000000840
+  lane17 (thread 17): 0x000000000844
+  lane18 (thread 18): 0x000000000848
+  lane19 (thread 19): 0x00000000084c
+  lane20 (thread 20): 0x000000000850
+  lane21 (thread 21): 0x000000000854
+  lane22 (thread 22): 0x000000000858
+  lane23 (thread 23): 0x00000000085c
+  lane24 (thread 24): 0x000000000860
+  lane25 (thread 25): 0x000000000864
+  lane26 (thread 26): 0x000000000868
+  lane27 (thread 27): 0x00000000086c
+  lane28 (thread 28): 0x000000000870
+  lane29 (thread 29): 0x000000000874
+  lane30 (thread 30): 0x000000000878
+  lane31 (thread 31): 0x00000000087c

--- a/examples/conv_bwd_weight_ima/example_ptx_vs_sass.txt
+++ b/examples/conv_bwd_weight_ima/example_ptx_vs_sass.txt
@@ -1,0 +1,11 @@
+# PTX: triton implements the masked X load with cp.async src-size operand (%r484).
+# When src-size=0, PTX ISA guarantees the source global address is NOT accessed.
+# ptxas miscompiles this into a predicated LDGSTS that DOES dereference the OOB address.
+
+# PTX (correct -- masked path sets src-size = 0, so no global read happens):
+104:   mov.b32   %r484, 0;
+106:   cp.async.ca.shared.global [ %r30 + 0 ], [ %rd5 + 0 ], 0x4, %r484;
+1220:  cp.async.ca.shared.global [ %r30 + 0 ], [ %rd49 + 0 ], 0x4, %r31;
+
+# SASS (ptxas output -- lowered to a predicated copy that DOES dereference R20):
+# /*2120*/  LDGSTS.E [R73+0x400], desc[UR6][R20.64], P6 ;

--- a/examples/conv_bwd_weight_ima/example_reg_trace_excerpt.txt
+++ b/examples/conv_bwd_weight_ima/example_reg_trace_excerpt.txt
@@ -1,0 +1,22 @@
+Address provenance for thread (0,0,0) at the faulting load (lane0, first loop iter):
+
+0x2020: regs=[(24, '0x0'), (25, '0xffffffff'), (255, '0x0')]
+       IMAD.SHL.U32 R24,R25,4    -> R24 = R25*4
+
+0x20d0: regs=[(16, '0x0'), (35, '0xfffffff0'), (18, '0x61c00000')]
+       IMAD.WIDE R16,R35,4,R18   -> R16:R17 = R35(index)*4 + R18(X base). R35=0xfffffff0 = -16 (neg padding halo index)
+
+0x20e0: regs=[(20, '0xfffffff0'), (16, '0x61bfffc0'), (24, '0xfffffffc'), (255, '0x0')]
+       IADD3 R20,R16,R24         -> R20(addr low) = 0x61bfffbc
+
+0x20f0: regs=[(21, '0xfffa'), (17, '0xfffa'), (25, '0x3')]
+       IMAD.X R21,R17,1,R25      -> R21(addr high)=0xfffa  (CORRUPTED: base high should be 0xfff8)
+
+0x2100: regs=[(26, '0x0'), (255, '0x0')]
+       ISETP.NE.U32 P6,R26,RZ    -> predicate for the load
+
+0x2110: regs=[(16, '0x61bfffc0'), (35, '0xfffffff0'), (22, '0x61c20000')]
+       IMAD.WIDE R16,R35,4,R22
+
+0x2120: regs=[(73, '0x400'), (20, '0x61bfffbc')]
+       LDGSTS.E [R73+0x400],desc[UR6][R20.64],P6  -> dereferences R21:R20 = 0xfffa_61bfffbc  (OOB ~17GB)

--- a/examples/conv_bwd_weight_ima/mini_repro_bwd_weight.py
+++ b/examples/conv_bwd_weight_ima/mini_repro_bwd_weight.py
@@ -1,0 +1,164 @@
+"""
+Standalone mini-reproducer for pytorch issue #187081:
+triton_convolution2d_bwd_weight illegal memory access on B200/GB200 (sm100).
+
+Failing autotune config: BLOCK_M=256, BLOCK_N=16, BLOCK_K=16, num_warps=4,
+num_stages=2. Kernel source extracted verbatim from the inductor-generated
+kernel (constexpr params baked in). Tensors match the failing test case
+(in=3, out=4, groups=1, kernel=1, stride=1, padding=1, dilation=2).
+
+Root cause: a ptxas optimization bug miscompiles the masked cp.async X load
+(`matrix_x = tl.load(x_ptrs, mask=mask_x)`); for thread (0,0,0) the predicate
+that should mask the load is wrong, so it reads ~17 GB out of bounds.
+Plain run: hard CUDA illegal memory access. compute-sanitizer pinpoints
+`triton_convolution2d_bwd_weight+0x2120` (SASS `LDGSTS.E ... P6`).
+Workaround / confirmation: DISABLE_PTXAS_OPT=1 -> 0 sanitizer errors, correct
+numerics. Upstream issue: pytorch/pytorch#187081.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def triton_convolution2d_bwd_weight(arg_X, arg_dY, out_ptr0):
+    KERNEL_H: tl.constexpr = 1
+    KERNEL_W: tl.constexpr = 1
+    PADDING_H: tl.constexpr = 1
+    PADDING_W: tl.constexpr = 1
+    STRIDE_H: tl.constexpr = 1
+    STRIDE_W: tl.constexpr = 1
+    DILATION_H: tl.constexpr = 2
+    DILATION_W: tl.constexpr = 2
+    GROUPS: tl.constexpr = 1
+    ALLOW_TF32: tl.constexpr = False
+    BLOCK_M: tl.constexpr = 256
+    BLOCK_N: tl.constexpr = 16
+    BLOCK_K: tl.constexpr = 16
+    INDEX_DTYPE: tl.constexpr = tl.int32
+    X = arg_X
+    dY = arg_dY
+
+    BATCH = 2
+    IN_C = 3
+    IN_H = 16
+    IN_W = 16
+    OUT_C = 4
+    OUT_H = 18
+    OUT_W = 18
+
+    stride_xn = 768
+    stride_xc = 256
+    stride_xh = 16
+    stride_xw = 1
+
+    stride_dyn = 1296
+    stride_dyc = 324
+    stride_dyh = 18
+    stride_dyw = 1
+
+    m0 = tl.program_id(0).to(INDEX_DTYPE) * BLOCK_M
+    oc = tl.program_id(1).to(INDEX_DTYPE) * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    group = 0
+    GROUP_IN_C = IN_C
+    GROUP_OUT_C = OUT_C
+
+    X_base = X + group * GROUP_IN_C * stride_xc
+    dY_base = dY + group * GROUP_OUT_C * stride_dyc
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    K_TOTAL = BATCH * OUT_H * OUT_W
+    for k in range(0, K_TOTAL, BLOCK_K):
+        idx_k = k + tl.arange(0, BLOCK_K)
+        n = (idx_k // (OUT_H * OUT_W)).to(tl.int32)
+        rem = idx_k % (OUT_H * OUT_W)
+        yh = (rem // OUT_W).to(tl.int32)
+        yw = (rem % OUT_W).to(tl.int32)
+
+        m = (m0 + tl.arange(0, BLOCK_M)).to(tl.int32)
+        ic = (m // (KERNEL_H * KERNEL_W)).to(tl.int32)
+        ij = m % (KERNEL_H * KERNEL_W)
+        i = (ij // KERNEL_W).to(tl.int32)
+        j = (ij % KERNEL_W).to(tl.int32)
+
+        xh = yh[:, None] * STRIDE_H - PADDING_H + i[None, :] * DILATION_H
+        xw = yw[:, None] * STRIDE_W - PADDING_W + j[None, :] * DILATION_W
+
+        x_ptrs = (
+            X_base
+            + n[:, None] * stride_xn
+            + ic[None, :] * stride_xc
+            + xh * stride_xh
+            + xw * stride_xw
+        )
+
+        mask_x = (
+            (n[:, None] < BATCH)
+            & (ic[None, :] < GROUP_IN_C)
+            & (xh >= 0)
+            & (xh < IN_H)
+            & (xw >= 0)
+            & (xw < IN_W)
+        )
+        matrix_x = tl.load(x_ptrs, mask=mask_x, other=0.0)
+        matrix_x = tl.trans(matrix_x)
+
+        dy_ptrs = (
+            dY_base
+            + n[:, None] * stride_dyn
+            + oc[None, :] * stride_dyc
+            + yh[:, None] * stride_dyh
+            + yw[:, None] * stride_dyw
+        )
+
+        mask_dy = (
+            (n[:, None] < BATCH)
+            & (oc[None, :] < GROUP_OUT_C)
+            & (yh[:, None] < OUT_H)
+            & (yw[:, None] < OUT_W)
+        )
+        matrix_dy = tl.load(dy_ptrs, mask=mask_dy, other=0.0)
+
+        acc += tl.dot(matrix_x, matrix_dy, allow_tf32=ALLOW_TF32)
+
+    m = m0 + tl.arange(0, BLOCK_M)
+    ic = m // (KERNEL_H * KERNEL_W)
+    ij = m % (KERNEL_H * KERNEL_W)
+    i = ij // KERNEL_W
+    j = ij % KERNEL_W
+
+    out_ic = ic
+    out_oc = oc + group * GROUP_OUT_C
+
+    mask = (out_ic[:, None] < GROUP_IN_C) & (oc[None, :] < GROUP_OUT_C)
+
+    tl.store(
+        out_ptr0
+        + (
+            tl.broadcast_to(
+                (out_ic[:, None]) + 3 * (out_oc[None, :]), [BLOCK_M, BLOCK_N]
+            )
+        ),
+        acc,
+        mask,
+    )
+
+
+def main():
+    torch.manual_seed(0)
+    dev = "cuda"
+    X = torch.randn(2, 3, 16, 16, device=dev)  # input
+    dY = torch.randn(2, 4, 18, 18, device=dev)  # grad_output
+    out = torch.zeros(4, 3, 1, 1, device=dev)  # grad_weight (OUT_C, IN_C, 1, 1)
+
+    grid = (1, 1, 1)  # ceil(3/512), ceil(4/16), GROUPS
+    triton_convolution2d_bwd_weight[grid](X, dY, out, num_warps=4, num_stages=2)
+    torch.cuda.synchronize()
+    print("OK", out.flatten().tolist())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:

Adds examples/conv_bwd_weight_ima/, a CUTracer case study for root-causing a
GPU illegal memory access down to a single SASS instruction.

The example distills pytorch/pytorch#187081: a TorchInductor-generated Triton
kernel (triton_convolution2d_bwd_weight) reads ~17 GB out of bounds on
Blackwell (sm100). It demonstrates a CUTracer workflow that is useful even
though CUTracer forces managed memory and so does not hard-crash: mem_addr_trace
captures the per-lane out-of-bounds addresses at the faulting load, and
reg_trace traces that address back to its source registers, pinning the bug on
ptxas (the PTX masks the cp.async load via src-size=0; ptxas lowers it to a
predicated LDGSTS that still dereferences the OOB address). DISABLE_PTXAS_OPT=1
on the same PTX yields 0 sanitizer errors.

Contents: a standalone torch+triton reproducer plus sample mem_addr_trace /
reg_trace / PTX-vs-SASS excerpts and a README.

Authored with the assistance of an AI coding agent.

Reviewed By: warrendeng

Differential Revision: D108450044


