### PR TITLE
[oss] fix meta internal checkup

### DIFF
--- a/python/cutracer/sanitize/cli.py
+++ b/python/cutracer/sanitize/cli.py
@@ -1,4 +1,4 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 """``cutracer sanitize`` — run a target under NVIDIA Compute Sanitizer.
 

--- a/scripts/listgpu.sh
+++ b/scripts/listgpu.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 # Script to list all GPU processes with detailed process information
 

--- a/tests/blackwell_blockscaled_gemm/gemm_72c_mxfp8_mxfp4.cu
+++ b/tests/blackwell_blockscaled_gemm/gemm_72c_mxfp8_mxfp4.cu
@@ -1,4 +1,5 @@
 /***************************************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) Meta Platforms, Inc. and affiliates.
  * Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/tests/blackwell_blockscaled_gemm/gemm_72c_mxfp8_mxfp4.cu
+++ b/tests/blackwell_blockscaled_gemm/gemm_72c_mxfp8_mxfp4.cu
@@ -1,5 +1,4 @@
 /***************************************************************************************************
- * SPDX-FileCopyrightText: Copyright (c) Meta Platforms, Inc. and affiliates.
  * Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *


### PR DESCRIPTION
Add copyright headers to comply to Meta's OSS project checkup ([T280112444](https://www.internalfb.com/T280112444))