### PR TITLE
Make racecheck parsing available to OSS CUTracer

### DIFF
--- a/python/cutracer/compute_sanitizer/parser.py
+++ b/python/cutracer/compute_sanitizer/parser.py
@@ -1,0 +1,205 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-strict
+
+"""Parse NVIDIA Compute Sanitizer racecheck output into neutral records.
+
+This module is part of the OSS package and deliberately has no dependency on
+CUTracer's internal analysis taxonomy.  Consumers adapt the parsed records to
+their own finding and reporting types.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List, Optional
+
+
+class RacecheckSeverity(str, Enum):
+    """Severity reported by a racecheck finding header."""
+
+    ERROR = "error"
+    WARNING = "warning"
+
+
+@dataclass(frozen=True)
+class RacecheckAccess:
+    """One access participating in a racecheck finding."""
+
+    role: str
+    access_type: str
+    function: str
+    offset: str
+    file: str
+    line: int
+    hazards: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class RacecheckFinding:
+    """One race block, independent of any downstream finding taxonomy."""
+
+    severity: RacecheckSeverity
+    accesses: List[RacecheckAccess]
+    raw_block: str
+
+    @property
+    def max_hazards(self) -> Optional[int]:
+        """Largest conflict count reported in this block, if any."""
+        counts = [a.hazards for a in self.accesses if a.hazards is not None]
+        return max(counts) if counts else None
+
+    @property
+    def access_kinds(self) -> List[str]:
+        """Access kinds in first-seen order."""
+        kinds: List[str] = []
+        for access in self.accesses:
+            if access.access_type not in kinds:
+                kinds.append(access.access_type)
+        return kinds
+
+    @property
+    def locations(self) -> List[str]:
+        """Source locations in first-seen order."""
+        locations: List[str] = []
+        for access in self.accesses:
+            location = f"{access.file}:{access.line}"
+            if location not in locations:
+                locations.append(location)
+        return locations
+
+
+@dataclass(frozen=True)
+class RacecheckSummary:
+    """Aggregate counts from the ``RACECHECK SUMMARY`` line."""
+
+    total_hazards: int
+    errors: int
+    warnings: int
+    raw: str
+
+
+@dataclass(frozen=True)
+class RacecheckParseResult:
+    """Structured output from one racecheck log."""
+
+    findings: List[RacecheckFinding]
+    summary: Optional[RacecheckSummary] = None
+    tool: str = "racecheck"
+
+
+# Compute Sanitizer prefixes its own output with this marker. Child process
+# output can be interleaved without it and must not terminate an open block.
+_PREFIX = "========="
+
+_HEADER_RE = re.compile(
+    r"^(?P<level>Error|Warning): Race reported between "
+    r"(?P<type>\w+) access at (?P<func>\S+)\+(?P<offset>0x[0-9a-fA-F]+) "
+    r"in (?P<file>.+?):(?P<line>\d+)\s*$"
+)
+_CONFLICT_RE = re.compile(
+    r"^and (?P<type>\w+) access at (?P<func>\S+)\+(?P<offset>0x[0-9a-fA-F]+) "
+    r"in (?P<file>.+?):(?P<line>\d+)"
+    r"(?:\s*\[(?P<hazards>\d+) hazards?\])?\s*$"
+)
+_SUMMARY_RE = re.compile(
+    r"RACECHECK SUMMARY: (?P<total>\d+) hazards? displayed "
+    r"\((?P<errors>\d+) errors?, (?P<warnings>\d+) warnings?\)"
+)
+
+
+def _required(groups: Dict[str, Optional[str]], name: str) -> str:
+    value = groups.get(name)
+    if value is None:
+        raise ValueError(f"racecheck parser missing required group: {name}")
+    return value
+
+
+def _build_access(groups: Dict[str, Optional[str]], role: str) -> RacecheckAccess:
+    hazards = groups.get("hazards")
+    return RacecheckAccess(
+        role=role,
+        access_type=_required(groups, "type"),
+        function=_required(groups, "func"),
+        offset=_required(groups, "offset"),
+        file=_required(groups, "file"),
+        line=int(_required(groups, "line")),
+        hazards=int(hazards) if hazards is not None else None,
+    )
+
+
+def _build_finding(
+    header: Dict[str, Optional[str]],
+    conflicts: List[Dict[str, Optional[str]]],
+    raw_lines: List[str],
+) -> RacecheckFinding:
+    severity = (
+        RacecheckSeverity.ERROR
+        if _required(header, "level") == "Error"
+        else RacecheckSeverity.WARNING
+    )
+    accesses = [_build_access(header, "primary")]
+    accesses.extend(_build_access(conflict, "conflict") for conflict in conflicts)
+    return RacecheckFinding(
+        severity=severity,
+        accesses=accesses,
+        raw_block="\n".join(raw_lines),
+    )
+
+
+def parse_racecheck_log(text: str) -> RacecheckParseResult:
+    """Parse racecheck stdout without depending on internal CUTracer types.
+
+    The parser is intentionally lenient: unrelated and interleaved child
+    output is ignored, malformed fragments produce no finding, and a missing
+    summary is represented by ``None``. Temporal RAW/WAR/WAW classification is
+    not inferred because racecheck output does not establish execution order.
+    """
+    findings: List[RacecheckFinding] = []
+    summary: Optional[RacecheckSummary] = None
+
+    header: Optional[Dict[str, Optional[str]]] = None
+    conflicts: List[Dict[str, Optional[str]]] = []
+    raw_lines: List[str] = []
+
+    def flush() -> None:
+        nonlocal header, conflicts, raw_lines
+        if header is not None:
+            findings.append(_build_finding(header, conflicts, raw_lines))
+        header = None
+        conflicts = []
+        raw_lines = []
+
+    for line in text.splitlines():
+        if not line.startswith(_PREFIX):
+            continue
+        body = line[len(_PREFIX) :].strip()
+
+        summary_match = _SUMMARY_RE.search(body)
+        if summary_match:
+            summary = RacecheckSummary(
+                total_hazards=int(summary_match["total"]),
+                errors=int(summary_match["errors"]),
+                warnings=int(summary_match["warnings"]),
+                raw=body,
+            )
+            continue
+
+        header_match = _HEADER_RE.match(body)
+        if header_match:
+            flush()
+            header = header_match.groupdict()
+            raw_lines = [body]
+            continue
+
+        if header is not None:
+            conflict_match = _CONFLICT_RE.match(body)
+            if conflict_match:
+                conflicts.append(conflict_match.groupdict())
+                raw_lines.append(body)
+                continue
+            flush()
+
+    flush()
+    return RacecheckParseResult(findings=findings, summary=summary)

--- a/python/cutracer/service/experiments/sanitizer.py
+++ b/python/cutracer/service/experiments/sanitizer.py
@@ -9,7 +9,7 @@ import time
 from typing import Callable, List, Optional
 
 from click import ClickException
-from cutracer.analyze.fb.compute_sanitizer.parser import (
+from cutracer.compute_sanitizer.parser import (
     parse_racecheck_log as parse_canonical_racecheck_log,
 )
 from cutracer.compute_sanitizer.run import (
@@ -44,28 +44,16 @@ def parse_racecheck_log(text: str) -> List[FindingRecord]:
     """Convert the canonical CUTracer parser output to service wire records."""
     records: List[FindingRecord] = []
     for finding in parse_canonical_racecheck_log(text).findings:
-        payload = finding.payload
-        accesses = payload.get("accesses", [])
-        primary = accesses[0] if isinstance(accesses, list) and accesses else {}
-        if not isinstance(primary, dict):
-            primary = {}
-
-        file = primary.get("file")
-        line = primary.get("line")
-        source = None
-        if isinstance(file, str) and isinstance(line, int):
-            source = SourceLoc(file=file, line=line)
-
-        kernel = primary.get("func")
-        count = payload.get("max_hazards", 1)
+        primary = finding.accesses[0]
+        count = finding.max_hazards
         records.append(
             FindingRecord(
                 source_tool="compute_sanitizer/racecheck",
                 error_type="race-condition",
-                kernel_name=kernel if isinstance(kernel, str) else None,
-                source=source,
-                count=count if isinstance(count, int) else 1,
-                raw=str(payload.get("raw_block", "")),
+                kernel_name=primary.function,
+                source=SourceLoc(file=primary.file, line=primary.line),
+                count=count if count is not None else 1,
+                raw=finding.raw_block,
             )
         )
     return records

--- a/python/tests/example_inputs/racecheck_clean.txt
+++ b/python/tests/example_inputs/racecheck_clean.txt
@@ -1,0 +1,4 @@
+========= COMPUTE-SANITIZER
+.......                                                                  [100%]
+7 passed in 5.01s
+========= RACECHECK SUMMARY: 0 hazards displayed (0 errors, 0 warnings)

--- a/python/tests/example_inputs/racecheck_hazard.txt
+++ b/python/tests/example_inputs/racecheck_hazard.txt
@@ -1,0 +1,14 @@
+========= COMPUTE-SANITIZER
+========= Error: Race reported between Write access at kernel_a+0x100 in kernels.py:42
+child process output may be interleaved
+=========     and Read access at kernel_a+0x200 in kernels.py:57 [3 hazards]
+=========     and Read access at kernel_a+0x240 in kernels.py:58 [5 hazards]
+=========
+========= Warning: Maximum number of hazards reached.
+=========
+========= Warning: Race reported between Read access at kernel_b+0x300 in other.py:9
+=========     and Write access at kernel_b+0x340 in other.py:12 [2 hazards]
+=========
+1 failed, 1 warning in 12.34s
+========= Target application returned an error
+========= RACECHECK SUMMARY: 7 hazards displayed (6 errors, 1 warning)

--- a/python/tests/test_base.py
+++ b/python/tests/test_base.py
@@ -20,6 +20,8 @@ REG_TRACE_LOG = EXAMPLE_INPUTS_DIR / "reg_trace_sample.log"
 KERNEL_EVENTS_NDJSON = EXAMPLE_INPUTS_DIR / "kernel_events_sample.ndjson"
 INVALID_SYNTAX_NDJSON = EXAMPLE_INPUTS_DIR / "invalid_syntax.ndjson"
 INVALID_SCHEMA_NDJSON = EXAMPLE_INPUTS_DIR / "invalid_schema.ndjson"
+RACECHECK_CLEAN = EXAMPLE_INPUTS_DIR / "racecheck_clean.txt"
+RACECHECK_HAZARD = EXAMPLE_INPUTS_DIR / "racecheck_hazard.txt"
 
 # Expected record counts for sample files
 REG_TRACE_NDJSON_RECORD_COUNT = 100

--- a/python/tests/test_compute_sanitizer_parser.py
+++ b/python/tests/test_compute_sanitizer_parser.py
@@ -1,0 +1,73 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Tests for the OSS Compute Sanitizer racecheck parser."""
+
+import unittest
+
+from cutracer.compute_sanitizer.parser import parse_racecheck_log, RacecheckSeverity
+from tests.test_base import RACECHECK_CLEAN, RACECHECK_HAZARD
+
+
+class ComputeSanitizerParserTest(unittest.TestCase):
+    def test_clean_log_has_no_findings(self) -> None:
+        result = parse_racecheck_log(RACECHECK_CLEAN.read_text())
+        self.assertEqual(result.findings, [])
+        self.assertIsNotNone(result.summary)
+        assert result.summary is not None
+        self.assertEqual(result.summary.total_hazards, 0)
+        self.assertEqual(result.summary.errors, 0)
+        self.assertEqual(result.summary.warnings, 0)
+
+    def test_hazard_log_parses_neutral_records(self) -> None:
+        result = parse_racecheck_log(RACECHECK_HAZARD.read_text())
+        self.assertEqual(len(result.findings), 2)
+
+        error, warning = result.findings
+        self.assertEqual(error.severity, RacecheckSeverity.ERROR)
+        self.assertEqual(error.max_hazards, 5)
+        self.assertEqual(error.access_kinds, ["Write", "Read"])
+        self.assertEqual(
+            error.locations, ["kernels.py:42", "kernels.py:57", "kernels.py:58"]
+        )
+        self.assertEqual(len(error.accesses), 3)
+        self.assertEqual(error.accesses[0].role, "primary")
+        self.assertEqual(error.accesses[0].function, "kernel_a")
+        self.assertEqual(error.accesses[1].hazards, 3)
+        self.assertIn("Race reported between", error.raw_block)
+        self.assertIn("child process output", RACECHECK_HAZARD.read_text())
+
+        self.assertEqual(warning.severity, RacecheckSeverity.WARNING)
+        self.assertEqual(warning.max_hazards, 2)
+        self.assertEqual(warning.access_kinds, ["Read", "Write"])
+
+        self.assertIsNotNone(result.summary)
+        assert result.summary is not None
+        self.assertEqual(result.summary.total_hazards, 7)
+        self.assertEqual(result.summary.errors, 6)
+        self.assertEqual(result.summary.warnings, 1)
+
+    def test_empty_and_malformed_input(self) -> None:
+        for text in ("", "garbage\n", "========= COMPUTE-SANITIZER\n"):
+            result = parse_racecheck_log(text)
+            self.assertEqual(result.findings, [])
+            self.assertIsNone(result.summary)
+
+    def test_summary_and_conflict_singular_grammar(self) -> None:
+        text = (
+            "========= Error: Race reported between Read access at "
+            "kernel+0x100 in test.py:7\n"
+            "========= and Write access at kernel+0x200 in test.py:9 "
+            "[1 hazard]\n"
+            "========= RACECHECK SUMMARY: 1 hazard displayed "
+            "(1 error, 0 warnings)\n"
+        )
+        result = parse_racecheck_log(text)
+        self.assertEqual(len(result.findings), 1)
+        self.assertEqual(result.findings[0].max_hazards, 1)
+        self.assertIsNotNone(result.summary)
+        assert result.summary is not None
+        self.assertEqual(result.summary.total_hazards, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_reduce_cli.py
+++ b/python/tests/test_reduce_cli.py
@@ -20,6 +20,9 @@ class ReduceCliTest(unittest.TestCase):
         self.isolated_filesystem = self.runner.isolated_filesystem()
         self.isolated_filesystem.__enter__()
         self.temp_dir = tempfile.mkdtemp()
+        self.cutracer_so = Path(self.temp_dir) / "cutracer.so"
+        self.cutracer_so.touch()
+        self.runtime_args = ["--cutracer-so", str(self.cutracer_so)]
 
         # Create a test delay config file matching DELAY_CONFIG_SCHEMA
         self.config_file = Path(self.temp_dir) / "delay_config.json"
@@ -150,6 +153,7 @@ class ReduceCliTest(unittest.TestCase):
             main,
             [
                 "reduce",
+                *self.runtime_args,
                 "--config",
                 str(self.config_file),
                 "--test",
@@ -159,6 +163,7 @@ class ReduceCliTest(unittest.TestCase):
 
         # Should fail when trying to run the nonexistent test script
         self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("No such file or directory", result.output)
 
     def test_reduce_basic_with_race(self):
         """Test basic reduce command with race always detected."""
@@ -169,6 +174,7 @@ class ReduceCliTest(unittest.TestCase):
             main,
             [
                 "reduce",
+                *self.runtime_args,
                 "--config",
                 str(self.config_file),
                 "--test",
@@ -193,6 +199,7 @@ class ReduceCliTest(unittest.TestCase):
             main,
             [
                 "reduce",
+                *self.runtime_args,
                 "--config",
                 str(self.config_file),
                 "--test",
@@ -201,7 +208,7 @@ class ReduceCliTest(unittest.TestCase):
         )
 
         self.assertNotEqual(result.exit_code, 0)
-        self.assertIn("Error", result.output)
+        self.assertIn("Initial config does not trigger the race", result.output)
 
     def test_reduce_verbose_output(self):
         """Test reduce with verbose output."""
@@ -209,6 +216,7 @@ class ReduceCliTest(unittest.TestCase):
             main,
             [
                 "reduce",
+                *self.runtime_args,
                 "--config",
                 str(self.config_file),
                 "--test",
@@ -227,6 +235,7 @@ class ReduceCliTest(unittest.TestCase):
             main,
             [
                 "reduce",
+                *self.runtime_args,
                 "--config",
                 str(self.config_file),
                 "--test",
@@ -250,6 +259,7 @@ class ReduceCliTest(unittest.TestCase):
             main,
             [
                 "reduce",
+                *self.runtime_args,
                 "--config",
                 str(self.config_file),
                 "--test",


### PR DESCRIPTION
Summary:
Move NVIDIA Compute Sanitizer racecheck syntax parsing into the shared
compute_sanitizer package and return vendor-neutral typed records. Keep the
internal analyzer taxonomy behind an fb-only adapter, and have the diagnosis
service consume the shared parser directly so OSS CLI imports no longer depend
on cutracer.analyze.fb.

Add OSS parser fixtures and tests covering clean logs, multiple findings,
interleaved child output, derived access metadata, malformed input, and
singular hazard grammar. Preserve the existing internal Finding contract.

Make reduce CLI tests provide an explicit temporary cutracer.so while running
inside Click isolated filesystems. This exercises the intended replay outcomes
in OSS without relying on the Buck-only bundled resource, and prevents negative
tests from passing early for the wrong missing-library reason.

Differential Revision: D113937171


